### PR TITLE
Add peripheral.Application teardown support

### DIFF
--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -53,7 +53,7 @@ class Application(dbus.service.Object):
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         self.mainloop = GObject.MainLoop()
         self.bus = dbus.SystemBus()
-        self.path = '/ukBaz/bluezero/application'
+        self.path = '/ukBaz/bluezero/application{}'.format(id(self))
         self.services = []
         dbus.service.Object.__init__(self, self.bus, self.path)
 
@@ -95,12 +95,13 @@ class Application(dbus.service.Object):
 
         print('setup ad_manager')
         ad_manager = bluezutils.get_advert_manager_interface()
-
+        self.ad_manager = ad_manager
         print('setup service_manager')
         service_manager = bluezutils.get_gatt_manager_interface()
-
+        self.service_manager = service_manager
         print('Advertise service')
         service_ad = Advertisement(self, 'peripheral')
+        self.service_ad = service_ad
         primary_uuid = self.get_primary_service()
         service_ad.add_service_uuid(primary_uuid)
 
@@ -121,6 +122,10 @@ class Application(dbus.service.Object):
             print('Closing Mainloop')
             self.mainloop.quit()
 
+    def stop(self):
+        self.ad_manager.UnregisterAdvertisement(self.service_ad.get_path())
+        self.service_manager.UnregisterApplication(self.get_path())
+        self.mainloop.quit()
 
 class Service(dbus.service.Object):
 

--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -382,7 +382,8 @@ class UserDescriptor(Descriptor):
 
     def __init__(self, name, characteristic):
         self.writable = 'writable-auxiliaries' in characteristic.flags
-        self.value = array.array('B', bytes(name, encoding='utf-8'))
+        #self.value = array.array('B', bytes(name, encoding='utf-8'))
+        self.value = array.array('B', bytes(name))
         self.value = self.value.tolist()
         Descriptor.__init__(
             self,

--- a/examples/toggle_services.py
+++ b/examples/toggle_services.py
@@ -1,0 +1,54 @@
+import sys
+import os
+sys.path.insert(0, os.path.split(os.path.dirname(os.path.realpath(__file__)))[0])
+
+from time import sleep
+from threading import Thread
+
+from bluezero import peripheral
+
+# Bluetooth Service
+
+service1 = peripheral.Service('12341000-1234-1234-1234-123456789abc', True)
+char1 = peripheral.Characteristic('12341002-1234-1234-1234-123456789abc',['read', 'write', 'notify'], service1)
+service1.add_characteristic(char1)
+
+service2 = peripheral.Service('12341000-1234-1234-1234-123456789def', True)
+char2 = peripheral.Characteristic('12341002-1234-1234-1234-123456789def',['read', 'write', 'notify'], service2)
+service2.add_characteristic(char2)
+
+
+app1 = peripheral.Application()
+app1.add_service(service1)
+
+app2 = peripheral.Application()
+app2.add_service(service2)
+
+
+TOGGLE_DELAY = 30
+def worker():
+    try:
+        print("Allowing the first app {} secs to run.".format(TOGGLE_DELAY))
+        sleep(TOGGLE_DELAY)
+        while True:
+            print("App1 down, App2 up")
+            app1.stop()
+            app2.start()
+            sleep(TOGGLE_DELAY)
+            print("App1 up, App2 down")
+            app1.start()
+            app2.stop()
+            sleep(TOGGLE_DELAY)
+
+    except KeyboardInterrupt:
+        print('KeyboardInterrupt')
+
+
+
+workerThread=Thread(target=worker)
+workerThread.daemon=False
+workerThread.start()
+
+# Start service and advertise
+app1.start()
+


### PR DESCRIPTION
Initial support for tearing down (stopping) an application and starting another one (perhaps with differnted services/advertisement) within the same Python script process.

Use case:  toggle between being a Physical Web beacon and a 'real' service.

Although this feature requires more testing and further dev it should not impact existing functionality. (other than adding a DBus visible ID being added to the object path to maintain uniqueness in the `/ukBaz/bluezero/` namespace)