### PR TITLE
Adjustments to adapter power states to help adapter tests pass.

### DIFF
--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -16,7 +16,6 @@ import dbus
 import dbus.mainloop.glib
 
 # python-bluezero imports
-from bluezero import tools
 from bluezero import constants
 
 # Main eventloop import
@@ -250,7 +249,7 @@ class Adapter:
             constants.ADAPTER_INTERFACE, 'Discovering')
 
     def _discovering_timeout(self):
-        """Test to see if discovering should stop"""
+        """Test to see if discovering should stop."""
         self._nearby_count += 1
         if self._nearby_count > self._nearby_timeout:
             self.stop_discovery()
@@ -259,6 +258,8 @@ class Adapter:
 
     def nearby_discovery(self, timeout=10):
         """Start discovery of nearby Bluetooth devices."""
+        if not self.powered():
+            self.powered('on')
         self._nearby_timeout = timeout
         self._nearby_count = 0
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -60,11 +60,12 @@ class TestBluezeroAdapter(dbusmock.DBusTestCase):
 
     def test_adapter_power(self):
         dongle = Adapter('/org/bluez/hci0')
+        dongle.powered('on')
         self.assertEqual(dongle.powered(), 1)
 
     def test_adapter_power_write(self):
         dongle = Adapter('/org/bluez/hci0')
-        dongle.powered(0)
+        dongle.powered('off')
         self.assertEqual(dongle.powered(), 0)
 
     def test_adapter_discoverable(self):


### PR DESCRIPTION
When running `python3 -m unittest tests.test_adapter` I had two test failures:
1. Discovering failed with a "resource not ready" - the adapter wasn't powered, so I added a test to turn the adapter on in `nearby_discovery()` if it isn't already on.
2. Adapters aren't powered up in the init(), so `test_adapter_power` wasn't returning the correct value.  I added a line to power on the adapter to match the test.

... if this isn't the correct behaviour for the adapter, feel free to amend the tests differently!
