### PR TITLE
update to fix device dbusmock test

### DIFF
--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -5,7 +5,6 @@ import dbus.mainloop.glib
 from gi.repository import GLib
 
 from bluezero import constants
-from bluezero import tools
 
 
 class Device:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -39,12 +39,13 @@ class TestBluezeroDevice(dbusmock.DBusTestCase):
         dongle = Adapter('/org/bluez/hci0')
 
         path = self.dbusmock_bluez.AddDevice('hci0',
-                                             '11:22:33:44:55:66', 'xxx')
+                                             '11:22:33:44:55:66',
+                                             'Peripheral Device')
         self.assertEqual(path,
                          '/org/bluez/' + adapter_name + '/dev_' +
                          address.replace(':', '_'))
         ble_dev = Device('/org/bluez/hci0/dev_11_22_33_44_55_66')
-        # found_name = ble_dev.name()
+        found_name = ble_dev.name()
         self.assertEqual(found_name, 'Peripheral Device')
 
 


### PR DESCRIPTION
If I got this right, removing the import of bluezero/tools (as per the fix for adapter) from `device.py` also fixes the device test.  (I also changed the alias that is set in the test so that it matches "Peripheral Device" - I hope I'm understanding it correctly!)