### PR TITLE
Fallback import of GLib to gobject

### DIFF
--- a/bluezero/GATT.py
+++ b/bluezero/GATT.py
@@ -1,11 +1,14 @@
 import dbus
 import dbus.mainloop.glib
-from gi.repository import GLib
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
 
 from bluezero import constants
 
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-mainloop = GLib.MainLoop()
+mainloop = GObject.MainLoop()
 
 
 def generic_error_cb(error):

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -19,7 +19,10 @@ import dbus.mainloop.glib
 from bluezero import constants
 
 # Main eventloop import
-from gi.repository import GLib
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
 
 
 # Initialise the mainloop
@@ -94,7 +97,7 @@ class Adapter:
 
         self._nearby_timeout = 10
         self._nearby_count = 0
-        self.mainloop = GLib.MainLoop()
+        self.mainloop = GObject.MainLoop()
 
         self.bus.add_signal_receiver(interfaces_added,
                                      dbus_interface=constants.DBUS_OM_IFACE,
@@ -218,7 +221,7 @@ class Adapter:
         self._nearby_timeout = timeout
         self._nearby_count = 0
 
-        GLib.timeout_add(1000, self._discovering_timeout)
+        GObject.timeout_add(1000, self._discovering_timeout)
         self.adapter_methods.StartDiscovery()
         self.mainloop.run()
 

--- a/bluezero/advertisement.py
+++ b/bluezero/advertisement.py
@@ -12,12 +12,15 @@ import dbus
 import dbus.exceptions
 import dbus.service
 import dbus.mainloop.glib
-from gi.repository import GLib
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
 
 from bluezero import constants
 
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-mainloop = GLib.MainLoop()
+mainloop = GObject.MainLoop()
 
 
 ########################################

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -8,7 +8,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import dbus
 import dbus.mainloop.glib
-from gi.repository import GLib
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
 
 from bluezero import constants
 
@@ -30,7 +33,7 @@ class Device:
         """
         self.bus = dbus.SystemBus()
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-        self.mainloop = GLib.MainLoop()
+        self.mainloop = GObject.MainLoop()
 
         self.remote_device_path = device_path
         self.remote_device_obj = self.bus.get_object(

--- a/bluezero/localGATT.py
+++ b/bluezero/localGATT.py
@@ -13,9 +13,6 @@ import dbus.exceptions
 import dbus.mainloop.glib
 import dbus.service
 
-# Main eventloop import
-from gi.repository import GLib
-
 # python-bluezero imports
 from bluezero import constants
 

--- a/bluezero/tools.py
+++ b/bluezero/tools.py
@@ -6,13 +6,16 @@ import subprocess
 # D-Bus import
 import dbus
 import dbus.mainloop.glib
-from gi.repository import GLib
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
 
 # python-bluezero constants import
 from bluezero import constants
 
 dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-mainloop = GLib.MainLoop()
+mainloop = GObject.MainLoop()
 
 
 def bluez_version():

--- a/examples/level100/cpu_temperature.py
+++ b/examples/level100/cpu_temperature.py
@@ -1,8 +1,10 @@
 # Standard modules
 import os
 import dbus
-from gi.repository import GLib
-import random
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
 
 # Bluezero modules
 from bluezero import tools
@@ -65,7 +67,7 @@ class TemperatureChrc(localGATT.Characteristic):
             return
 
         print('Starting timer event')
-        GLib.timeout_add(500, self.temperature_cb)
+        GObject.timeout_add(500, self.temperature_cb)
 
     def ReadValue(self, options):
         return dbus.Array(

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -3,9 +3,7 @@ import sys
 import unittest
 
 import dbus
-import dbus.mainloop.glib
 import dbusmock
-from gi.repository import GLib
 
 from bluezero.adapter import Adapter
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -3,9 +3,7 @@ import sys
 import unittest
 
 import dbus
-import dbus.mainloop.glib
 import dbusmock
-from gi.repository import GLib
 
 from bluezero.adapter import Adapter
 from bluezero.device import Device


### PR DESCRIPTION
In some modules GLib was being imported without a fallback to gobject which makes this not work with some older libraries.  I removed the import entirely from a couple files that were not using the mainloop.