### PR TITLE
extra carriage return before main to pass pycodestyle.

### DIFF
--- a/examples/level100/blinkt_ble.py
+++ b/examples/level100/blinkt_ble.py
@@ -76,6 +76,7 @@ class ble:
         # self.light.StartNotify()
         tools.start_mainloop()
 
+
 if __name__ == '__main__':
     link = ble()
     blinkt_ble = blinkt(link)

--- a/examples/level100/cpu_temperature.py
+++ b/examples/level100/cpu_temperature.py
@@ -140,6 +140,7 @@ class ble:
         # self.light.StartNotify()
         tools.start_mainloop()
 
+
 if __name__ == '__main__':
     print('CPU temperature is {}C'.format(get_cpu_temperature()))
     print(sint16(get_cpu_temperature()))

--- a/examples/level100/light_switch.py
+++ b/examples/level100/light_switch.py
@@ -74,6 +74,7 @@ class ble:
         # self.light.StartNotify()
         tools.start_mainloop()
 
+
 if __name__ == '__main__':
     link = ble()
     hat = board(link)


### PR DESCRIPTION
I'm slightly surprised it didn't fail it for lack of docstrings, but I guess different style checkers pick up on different things!