### PR TITLE
Squash DBus references to level 100 files only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_script:
 script:
   # Shared
   - coverage run -m unittest -v tests.test_tools
+  - coverage run -m unittest -v tests.test_dbus_tools
   # Level 100
   - coverage run --append -m unittest -v tests.test_adapter
   - coverage run --append -m unittest -v tests.test_advertisement
@@ -49,6 +50,7 @@ script:
   - coverage run --append -m unittest -v tests.test_gatt
   # Level 10
   - coverage run --append -m unittest -v tests.test_broadcaster
+  - coverage run --append -m unittest -v tests.test_central
   - coverage run --append -m unittest -v tests.test_peripheral
   # Level 1
   - coverage run --append -m unittest -v tests.test_blinkt

--- a/README.rst
+++ b/README.rst
@@ -5,10 +5,6 @@ python-bluezero
     :target: https://travis-ci.org/ukBaz/python-bluezero
     :alt: Build Status
 
-.. image:: https://codeclimate.com/github/ukBaz/python-bluezero/badges/gpa.svg
-   :target: https://codeclimate.com/github/ukBaz/python-bluezero
-   :alt: Code Climate
-
 .. image:: https://img.shields.io/codecov/c/github/ukBaz/python-bluezero/master.svg?maxAge=2592000
     :target: https://codecov.io/github/ukBaz/python-bluezero
     :alt: Code Coverage

--- a/bluezero/blinkt.py
+++ b/bluezero/blinkt.py
@@ -13,10 +13,7 @@ except ImportError:
         def emit(self, record):
             pass
 
-from bluezero import constants
-from bluezero import tools
-from bluezero import adapter
-from bluezero import device
+from bluezero import central
 
 
 BLINKT_SRV = '0000FFF0-0000-1000-8000-00805F9B34FB'
@@ -31,74 +28,37 @@ class BLE_blinkt:
     """
     Class to simplify interacting with a microbit over Bluetooth Low Energy
     """
-    def __init__(self, name=None, address=None):
+    def __init__(self, device_addr, adapter_addr=None):
         """
         Initialization of an instance of a remote Blinkt BLE device
         :param name: Will look for a BLE device with this string in its name
         :param address: Will look for a BLE device with this address
          (Currently not implemented)
         """
-        self.name = name
-        self.address = address
-        self.dongle = adapter.Adapter(adapter.list_adapters()[0])
-        if not self.dongle.powered:
-            self.dongle.powered = True
-        logger.debug('Adapter powered')
-        logger.debug('Start discovery')
-        self.dongle.nearby_discovery()
-        device_path = None
-        if name is not None:
-            device_path = tools.get_dbus_path(
-                constants.DEVICE_INTERFACE,
-                'Name',
-                name)
-        elif address is not None:
-            device_path = tools.get_dbus_path(
-                constants.DEVICE_INTERFACE,
-                'Address',
-                address)
-
-        self.blnkt = device.Device(device_path[0])
-
-        self.blinkt_srv_path = None
-        self.blinkt_chrc_path = None
+        self.blinkt_dev = central.Central(adapter_addr=adapter_addr,
+                                          device_addr=device_addr)
+        self.blinkt_data = self.blinkt_dev.add_characteristic(BLINKT_SRV,
+                                                              BLINKT_CHRC)
 
     @property
     def connected(self):
         """Indicate whether the remote device is currently connected."""
-        return self.blnkt.connected
+        return self.blinkt_dev.connected
 
     def connect(self):
         """
         Connect to the specified Blinkt BLE for this instance
         """
-        self.blnkt.connect()
-        while not self.blnkt.services_resolved:
+        self.blinkt_dev.connect()
+        while not self.blinkt_dev.services_resolved:
             sleep(0.5)
-        self._get_dbus_paths()
-
-    def _get_dbus_paths(self):
-        """
-        Utility function to get the paths for UUIDs
-        :return:
-        """
-        self.blinkt_srv_path = tools.uuid_dbus_path(
-            constants.GATT_SERVICE_IFACE,
-            BLINKT_SRV)[0]
-        self.blinkt_chrc_path = tools.uuid_dbus_path(
-            constants.GATT_CHRC_IFACE,
-            BLINKT_CHRC)[0]
-        self.blinkt_obj = tools.get_dbus_obj(constants.BLUEZ_SERVICE_NAME,
-                                             self.blinkt_chrc_path)
-
-        self.blinkt_iface = tools.get_dbus_iface(constants.GATT_CHRC_IFACE,
-                                                 self.blinkt_obj)
+        self.blinkt_dev.load_gatt()
 
     def disconnect(self):
         """
         Disconnect from the Blinkt BLE device
         """
-        self.blnkt.disconnect()
+        self.blnkt_dev.disconnect()
 
     def _set_all(self, red, green, blue):
         """
@@ -107,7 +67,7 @@ class BLE_blinkt:
         :param green: Integer between 0 - 255
         :param blue: Integer between 0 - 255
         """
-        self.blinkt_iface.WriteValue([0x06, 0x01, red, green, blue], ())
+        self.blinkt_data.value = [0x06, 0x01, red, green, blue]
 
     def set_all(self, red, green, blue):
         """
@@ -132,5 +92,4 @@ class BLE_blinkt:
         :param green: integer in range 0 to 255
         :param blue: integer in range 0 to 255
         """
-        self.blinkt_iface.WriteValue([0x07, 0x02, 0x00,
-                                     pixel, red, green, blue], ())
+        self.blinkt_data.value = [0x07, 0x02, 0x00, pixel, red, green, blue]

--- a/bluezero/broadcaster.py
+++ b/bluezero/broadcaster.py
@@ -1,7 +1,7 @@
 """
 The level 10 file for creating beacons
 """
-from bluezero import tools
+from bluezero import dbus_tools
 from bluezero import adapter
 from bluezero import constants
 from bluezero import advertisement
@@ -71,9 +71,9 @@ class Beacon:
         ad_manager.register_advertisement(self.broadcaster, {})
 
         try:
-            tools.start_mainloop()
+            dbus_tools.start_mainloop()
         except KeyboardInterrupt:
-            tools.stop_mainloop()
+            dbus_tools.stop_mainloop()
             ad_manager.unregister_advertisement(self.broadcaster)
         finally:
             pass

--- a/bluezero/central.py
+++ b/bluezero/central.py
@@ -1,0 +1,85 @@
+"""Classes that represent the GATT features of a remote device."""
+
+from time import sleep
+
+import logging
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+from bluezero import adapter
+from bluezero import device
+from bluezero import GATT
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+logger.addHandler(NullHandler())
+
+
+def generic_error_cb(error):
+    """Generic Error Callback function."""
+    logger.error('D-Bus call failed: ' + str(error))
+    mainloop.quit()
+
+
+class Central:
+    """Create a BLE instance taking the Central role."""
+
+    def __init__(self, device_addr, adapter_addr=None):
+        if adapter_addr is None:
+            self.dongle = adapter.Adapter(adapter.list_adapters()[0])
+            logger.debug('Adapter is: {}'.format(self.dongle.address))
+        else:
+            self.dongle = adapter.Adapter(adapter_addr)
+        if not self.dongle.powered:
+            self.dongle.powered = True
+            logger.debug('Adapter was off, now powered on')
+        self.rmt_device = device.Device(adapter_addr, device_addr)
+
+        self._characteristics = []
+
+    def add_characteristic(self, srv_uuid, chrc_uuid):
+        chrc_hndl = GATT.Characteristic(self.dongle.address,
+                                        self.rmt_device.address,
+                                        srv_uuid,
+                                        chrc_uuid)
+        self._characteristics.append(chrc_hndl)
+        return chrc_hndl
+
+    def load_gatt(self):
+        for chrc in self._characteristics:
+            chrc.resolve_gatt()
+
+    def read_value(self, chrc_name):
+        return self.chrc_objs[chrc_name].value
+
+    @property
+    def services_resolved(self):
+        return self.rmt_device.services_resolved
+
+    @property
+    def connected(self):
+        """Indicate whether the remote device is currently connected."""
+        return self.rmt_device.connected
+
+    def connect(self, profile=None):
+        """
+        Initiate a connection to the remote device.
+
+        :param address: unused
+        :param profile: (optional) profile to use for the connection.
+        """
+        if profile is None:
+            self.rmt_device.connect()
+        else:
+            self.rmt_device.connect(profile)
+        while not self.rmt_device.services_resolved:
+            sleep(0.5)
+        self.load_gatt()
+
+    def disconnect(self):
+        """Disconnect from the remote device."""
+        self.rmt_device.disconnect()

--- a/bluezero/dbus_tools.py
+++ b/bluezero/dbus_tools.py
@@ -1,0 +1,303 @@
+"""Utility functions for python-bluezero."""
+
+# Standard libraries
+import subprocess
+import logging
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+# D-Bus import
+import dbus
+import dbus.mainloop.glib
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
+
+# python-bluezero constants import
+from bluezero import constants
+
+dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+mainloop = GObject.MainLoop()
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+logger.addHandler(NullHandler())
+
+
+def bluez_version():
+    """
+    get the version of the BlueZ daemon being used on the system
+    :return: String of BlueZ version
+    """
+    p = subprocess.Popen(['bluetoothctl', '-v'], stdout=subprocess.PIPE)
+    ver = p.communicate()
+    return str(ver[0].decode().rstrip())
+
+
+def interfaces_added(path, interfaces):
+    if constants.DEVICE_INTERFACE in interfaces:
+        logger.debug('Device added at {}'.format(path))
+
+
+def properties_changed(interface, changed, invalidated, path):
+    if constants.DEVICE_INTERFACE in interface:
+        for prop in changed:
+            logger.debug(
+                '{}:{} Property {} new value {}'.format(interface,
+                                                        path,
+                                                        prop,
+                                                        changed[prop]))
+
+
+def get_dbus_obj(dbus_path):
+    bus = dbus.SystemBus()
+    return bus.get_object(constants.BLUEZ_SERVICE_NAME, dbus_path)
+
+
+def get_dbus_iface(iface, dbus_obj):
+    return dbus.Interface(dbus_obj, iface)
+
+
+def get_managed_objects():
+    """Return the objects currently managed by the DBus Object Manager."""
+    bus = dbus.SystemBus()
+    manager = dbus.Interface(bus.get_object(
+        constants.BLUEZ_SERVICE_NAME, '/'),
+        constants.DBUS_OM_IFACE)
+    return manager.GetManagedObjects()
+
+
+def get_dbus_path(iface, prop, value):
+    response = []
+    objects = get_managed_objects()
+    for obj, ifaces in objects.items():
+        if iface in ifaces.keys():
+            if prop in ifaces[iface]:
+                if value in ifaces[iface][prop]:
+                    response.append(obj)
+
+    return response
+
+
+def uuid_dbus_path(iface, UUID):
+    """
+    Return the DBus object path currently managed by the DBus Object Manager
+    for a given UUID.
+
+    :param iface: BlueZ interface of interest
+    :param UUID: 128-bit UUID
+    :return: list of DBus object paths that match given UUID
+
+    >>> from bluezero import tools
+    >>> from bluezero import constants
+    >>> tools.uuid_dbus_path(constants.GATT_SERVICE_IFACE,
+                             'e95dd91d-251d-470a-a062-fa1922dfa9a8')
+    """
+    response = []
+    objects = get_managed_objects()
+    for obj, ifaces in objects.items():
+        if iface in ifaces.keys():
+            if ifaces[iface]['UUID'] == UUID.lower():
+                response.append(obj)
+
+    return response
+
+
+def device_dbus_path(iface, search_value):
+    """
+    Return the DBus object path currently managed by the DBus Object Manager
+    for a given Device. It looks at the device name containing the substring
+
+    :param iface: BlueZ interface of interest
+    :param search_value: sub-string to find
+    :return: list of DBus object paths that match given device name
+
+    >>> from bluezero import tools
+    >>> from bluezero import constants
+    >>> devices = tools.device_dbus_path(constants.DEVICE_INTERFACE, 'puteg')
+    """
+    response = []
+    objects = get_managed_objects()
+    for obj, ifaces in objects.items():
+        if iface in ifaces.keys():
+            if search_value in ifaces[iface]['Name']:
+                response.append(obj)
+
+    return response
+
+
+def _get_dbus_path2(objects, parent_path, iface_in, prop, value):
+    if parent_path is None:
+        raise InvalidSearch
+    for path, iface in objects.items():
+        props = iface.get(iface_in)
+        if props is None:
+            continue
+        if props[prop].lower() == value.lower() and \
+                path.startswith(parent_path):
+            return path
+
+
+def get_dbus_path(adapter=None,
+                  device=None,
+                  service=None,
+                  characteristic=None,
+                  descriptor=None):
+    bus = dbus.SystemBus()
+    manager = dbus.Interface(
+        bus.get_object(constants.BLUEZ_SERVICE_NAME, '/'),
+        constants.DBUS_OM_IFACE)
+    mngd_objs = manager.GetManagedObjects()
+
+    _dbus_obj_path = None
+
+    if adapter is not None:
+        _dbus_obj_path = _get_dbus_path2(mngd_objs,
+                                         '/org/bluez',
+                                         constants.ADAPTER_INTERFACE,
+                                         'Address',
+                                         adapter)
+
+    if device is not None:
+        _dbus_obj_path = _get_dbus_path2(mngd_objs,
+                                         _dbus_obj_path,
+                                         constants.DEVICE_INTERFACE,
+                                         'Address',
+                                         device)
+
+    if service is not None:
+        _dbus_obj_path = _get_dbus_path2(mngd_objs,
+                                         _dbus_obj_path,
+                                         constants.GATT_SERVICE_IFACE,
+                                         'UUID',
+                                         service)
+
+    if characteristic is not None:
+        _dbus_obj_path = _get_dbus_path2(mngd_objs,
+                                         _dbus_obj_path,
+                                         constants.GATT_CHRC_IFACE,
+                                         'UUID',
+                                         characteristic)
+
+    if descriptor is not None:
+        _dbus_obj_path = _get_dbus_path2(mngd_objs,
+                                         _dbus_obj_path,
+                                         constants.GATT_DESC_IFACE,
+                                         'UUID',
+                                         descriptor)
+    return _dbus_obj_path
+
+
+def get_profile_path(adapter,
+                     device,
+                     profile):
+    bus = dbus.SystemBus()
+    manager = dbus.Interface(
+        bus.get_object(constants.BLUEZ_SERVICE_NAME, '/'),
+        constants.DBUS_OM_IFACE)
+    mngd_objs = manager.GetManagedObjects()
+
+    _dbus_obj_path = None
+
+    if adapter is not None:
+        _dbus_obj_path = _get_dbus_path2(mngd_objs,
+                                         '/org/bluez',
+                                         constants.ADAPTER_INTERFACE,
+                                         'Address',
+                                         adapter)
+    if device is not None:
+        _dbus_obj_path = _get_dbus_path2(mngd_objs,
+                                         _dbus_obj_path,
+                                         constants.DEVICE_INTERFACE,
+                                         'Address',
+                                         device)
+
+    if profile is not None:
+        _dbus_obj_path = _get_dbus_path2(mngd_objs,
+                                         _dbus_obj_path,
+                                         constants.GATT_SERVICE_IFACE,
+                                         'UUID',
+                                         profile)
+    return _dbus_obj_path
+
+
+def get_iface(adapter=None,
+              device=None,
+              service=None,
+              characteristic=None,
+              descriptor=None):
+
+    if adapter is not None:
+        _iface = constants.ADAPTER_INTERFACE
+
+    if device is not None:
+        _iface = constants.DEVICE_INTERFACE
+
+    if service is not None:
+        _iface = constants.GATT_SERVICE_IFACE
+
+    if characteristic is not None:
+        _iface = constants.GATT_CHRC_IFACE
+
+    if descriptor is not None:
+        _iface = constants.GATT_DESC_IFACE
+
+    return _iface
+
+
+def get_methods(adapter=None,
+                device=None,
+                service=None,
+                characteristic=None,
+                descriptor=None):
+
+    path_obj = get_dbus_path(adapter,
+                             device,
+                             service,
+                             characteristic,
+                             descriptor)
+
+    iface = get_iface(adapter,
+                      device,
+                      service,
+                      characteristic,
+                      descriptor)
+
+    return get_dbus_iface(iface, get_dbus_obj(path_obj))
+
+
+def get_props(adapter=None,
+              device=None,
+              service=None,
+              characteristic=None,
+              descriptor=None):
+
+    path_obj = get_dbus_path(adapter,
+                             device,
+                             service,
+                             characteristic,
+                             descriptor)
+
+    return get_dbus_iface(dbus.PROPERTIES_IFACE, path_obj)
+
+
+#############################
+# Interface search functions
+#############################
+
+def start_mainloop():
+    mainloop.run()
+
+
+def stop_mainloop():
+    mainloop.quit()
+
+
+def generic_error_cb(error):
+    print('D-Bus call failed: ' + str(error))
+    mainloop.quit()

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -22,6 +22,7 @@ except ImportError:
             pass
 
 from bluezero import constants
+from bluezero import dbus_tools
 
 
 logger = logging.getLogger(__name__)
@@ -36,17 +37,19 @@ class Device:
     Bluetooth device via the D-Bus.
     """
 
-    def __init__(self, device_path):
+    def __init__(self, adapter_addr, device_addr):
         """Default initialiser.
 
-        Creates the D-Bus interface to the specified remote Bluetooth device.
-        The DBus path must be specified.
+        Creates object for the specified remote Bluetooth device.
+        This is on the specified adapter specified.
 
         :param device_path: DBus path to the remote Bluetooth device.
         """
         self.bus = dbus.SystemBus()
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         self.mainloop = GObject.MainLoop()
+
+        device_path = dbus_tools.get_dbus_path(adapter_addr, device_addr)
 
         self.remote_device_path = device_path
         self.remote_device_obj = self.bus.get_object(
@@ -236,11 +239,10 @@ class Device:
             constants.DEVICE_INTERFACE,
             'ServicesResolved')
 
-    def connect(self, address=None, profile=None):
+    def connect(self, profile=None):
         """
         Initiate a connection to the remote device.
 
-        :param address: unused
         :param profile: (optional) profile to use for the connection.
         """
         if profile is None:

--- a/bluezero/tools.py
+++ b/bluezero/tools.py
@@ -1,264 +1,33 @@
 """Utility functions for python-bluezero."""
 
-# Standard libraries
-import subprocess
 
-# D-Bus import
-import dbus
-import dbus.mainloop.glib
-try:
-    from gi.repository import GObject
-except ImportError:
-    import gobject as GObject
-
-# python-bluezero constants import
-from bluezero import constants
-
-dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-mainloop = GObject.MainLoop()
+def int_to_uint16(value_in):
+    bin_string = '{:016b}'.format(value_in)
+    big_byte = int(bin_string[0:8], 2)
+    little_byte = int(bin_string[8:16], 2)
+    return [little_byte, big_byte]
 
 
-def bluez_version():
-    """
-    get the version of the BlueZ daemon being used on the system
-    :return: String of BlueZ version
-    """
-    p = subprocess.Popen(['bluetoothctl', '-v'], stdout=subprocess.PIPE)
-    ver = p.communicate()
-    return str(ver[0].decode().rstrip())
+def sint16_to_int(bytes):
+    return int.from_bytes(bytes, byteorder='little', signed=True)
 
 
-def get_dbus_obj(iface, dbus_path):
-    bus = dbus.SystemBus()
-    return bus.get_object(iface, dbus_path)
+def bytes_to_xyz(bytes):
+    x = sint16_to_int(bytes[0:2]) / 1000
+    y = sint16_to_int(bytes[2:4]) / 1000
+    z = sint16_to_int(bytes[4:6]) / 1000
+
+    return [x, y, z]
 
 
-def get_dbus_iface(iface, dbus_obj):
-    return dbus.Interface(dbus_obj, iface)
+def int_to_uint32(value_in):
+    bin_string = '{0:032b}'.format(value_in)
+    octet0 = int(bin_string[25:32], 2)
+    octet1 = int(bin_string[17:24], 2)
+    octet2 = int(bin_string[9:16], 2)
+    octet3 = int(bin_string[0:8], 2)
 
-
-def get_managed_objects():
-    """Return the objects currently managed by the DBus Object Manager."""
-    bus = dbus.SystemBus()
-    manager = dbus.Interface(bus.get_object(
-        constants.BLUEZ_SERVICE_NAME, '/'),
-        constants.DBUS_OM_IFACE)
-    return manager.GetManagedObjects()
-
-
-def get_dbus_path(iface, prop, value):
-    response = []
-    objects = get_managed_objects()
-    for obj, ifaces in objects.items():
-        if iface in ifaces.keys():
-            if prop in ifaces[iface]:
-                if value in ifaces[iface][prop]:
-                    response.append(obj)
-
-    return response
-
-
-def uuid_dbus_path(iface, UUID):
-    """
-    Return the DBus object path currently managed by the DBus Object Manager
-    for a given UUID.
-
-    :param iface: BlueZ interface of interest
-    :param UUID: 128-bit UUID
-    :return: list of DBus object paths that match given UUID
-
-    >>> from bluezero import tools
-    >>> from bluezero import constants
-    >>> tools.uuid_dbus_path(constants.GATT_SERVICE_IFACE,
-                             'e95dd91d-251d-470a-a062-fa1922dfa9a8')
-    """
-    response = []
-    objects = get_managed_objects()
-    for obj, ifaces in objects.items():
-        if iface in ifaces.keys():
-            if ifaces[iface]['UUID'] == UUID.lower():
-                response.append(obj)
-
-    return response
-
-
-def device_dbus_path(iface, search_value):
-    """
-    Return the DBus object path currently managed by the DBus Object Manager
-    for a given Device. It looks at the device name containing the substring
-
-    :param iface: BlueZ interface of interest
-    :param search_value: sub-string to find
-    :return: list of DBus object paths that match given device name
-
-    >>> from bluezero import tools
-    >>> from bluezero import constants
-    >>> devices = tools.device_dbus_path(constants.DEVICE_INTERFACE, 'puteg')
-    """
-    response = []
-    objects = get_managed_objects()
-    for obj, ifaces in objects.items():
-        if iface in ifaces.keys():
-            if search_value in ifaces[iface]['Name']:
-                response.append(obj)
-
-    return response
-
-
-def find_adapter(pattern=None):
-    """Find a Bluetooth adapter from the DBus Object Manager.
-
-    :param pattern: (optional) pattern to match when looking for a specific
-                    adapter.
-
-    ... seealso:: :func:`find_adapter_in_objects`
-    """
-    return find_adapter_in_objects(get_managed_objects(), pattern)
-
-
-def find_adapter_in_objects(objects, pattern=None):
-    """Find a Bluetooth adapter filtered by pattern in objects.
-
-    :param objects: list of DBus managed objects from `get_managed_objects()`
-    :param pattern: (optional) pattern to match when looking for a specific
-                    adapter.
-
-    ... seealso:: :func: `get_managed_objects()`
-    """
-    bus = dbus.SystemBus()
-    for path, ifaces in objects.items():
-        adapter = ifaces.get(constants.ADAPTER_INTERFACE)
-        if adapter is None:
-            continue
-        if (not pattern or
-                pattern == adapter['Address'] or
-                path.endswith(pattern)):
-            obj = bus.get_object(constants.BLUEZ_SERVICE_NAME, path)
-            return dbus.Interface(obj, constants.ADAPTER_INTERFACE)
-    raise Exception('No Bluetooth adapter found')
-
-
-def find_device(device_address, adapter_pattern=None):
-    """Find a device from the DBus Object Manager.
-
-    :param device_address: device address that needs to be found
-    :param pattern: (optional) pattern to match when looking for a specific
-                    device.
-
-    ... seealso:: :func:`find_device_in_objects`
-    """
-    return find_device_in_objects(
-        get_managed_objects(),
-        device_address,
-        adapter_pattern)
-
-
-def find_device_in_objects(objects, device_address, adapter_pattern=None):
-    """Find a device in the managed DBus Objects.
-
-    :param objects: list of DBus managed objects from `get_managed_objects()`
-    :param device_address: device address that needs to be found
-    :param pattern: (optional) pattern to match when looking for a specific
-                    device.
-
-    """
-    bus = dbus.SystemBus()
-    path_prefix = ''
-    if adapter_pattern:
-        adapter = find_adapter_in_objects(objects, adapter_pattern)
-        path_prefix = adapter.object_path
-    for path, ifaces in objects.items():
-        device = ifaces.get(constants.DEVICE_INTERFACE)
-        if device is None:
-            continue
-        if (device['Address'] == device_address and
-                path.startswith(path_prefix)):
-            obj = bus.get_object(constants.BLUEZ_SERVICE_NAME, path)
-            return dbus.Interface(obj, constants.DEVICE_INTERFACE)
-
-    raise Exception('Bluetooth device not found')
-
-##########################
-# GATT Interface functions
-##########################
-
-
-def get_gatt_manager_interface():
-    """Return the DBus Interface for a Bluez GATT Manager."""
-    return dbus.Interface(
-        dbus.SystemBus().get_object(constants.BLUEZ_SERVICE_NAME,
-                                    '/org/bluez/hci0'),
-        constants.GATT_MANAGER_IFACE)
-
-
-def get_gatt_service_interface():
-    """Return the DBus Interface for a Bluez GATT Service."""
-    return dbus.Interface(
-        dbus.SystemBus().get_object(constants.BLUEZ_SERVICE_NAME,
-                                    '/org/bluez/hci0'),
-        constants.GATT_SERVICE_IFACE)
-
-
-def get_gatt_characteristic_interface():
-    """Return the DBus Interface for a Bluez GATT Characteristic."""
-    return dbus.Interface(
-        dbus.SystemBus().get_object(constants.BLUEZ_SERVICE_NAME,
-                                    '/org/bluez/hci0'),
-        constants.GATT_CHRC_IFACE)
-
-
-def get_gatt_descriptor_interface():
-    """Return the DBus Interface for a Bluez GATT Descriptor."""
-    return dbus.Interface(
-        dbus.SystemBus().get_object(constants.BLUEZ_SERVICE_NAME,
-                                    '/org/bluez/hci0'),
-        constants.GATT_DESC_IFACE)
-
-
-def get_advert_manager_interface():
-    """Return the DBus Interface for a Bluez GATT LE Advertising Manager."""
-    return dbus.Interface(
-        dbus.SystemBus().get_object(constants.BLUEZ_SERVICE_NAME,
-                                    '/org/bluez/hci0'),
-        constants.LE_ADVERTISING_MANAGER_IFACE)
-
-#############################
-# Interface search functions
-#############################
-
-
-def find_ad_adapter(bus):
-    """Find the advertising manager interface.
-
-    :param bus: D-Bus bus object that is searched.
-    """
-    remote_om = dbus.Interface(
-        bus.get_object(constants.BLUEZ_SERVICE_NAME, '/'),
-        constants.DBUS_OM_IFACE)
-    objects = remote_om.GetManagedObjects()
-
-    for o, props in objects.items():
-        if constants.LE_ADVERTISING_MANAGER_IFACE in props:
-            return o
-
-    return None
-
-
-def find_gatt_adapter(bus):
-    """Find the GATT manager interface.
-
-    :param bus: D-Bus bus object that is searched.
-    """
-    remote_om = dbus.Interface(
-        bus.get_object(constants.BLUEZ_SERVICE_NAME, '/'),
-        constants.DBUS_OM_IFACE)
-    objects = remote_om.GetManagedObjects()
-
-    for o, props in objects.items():
-        if constants.GATT_MANAGER_IFACE in props:
-            return o
-
-    return None
+    return [octet0, octet1, octet2,  octet3]
 
 
 def url_to_advert(url, frame_type, tx_power):
@@ -320,45 +89,3 @@ def url_to_advert(url, frame_type, tx_power):
             service_data.extend([ord(url[x])])
 
     return service_data
-
-
-def start_mainloop():
-    mainloop.run()
-
-
-def stop_mainloop():
-    mainloop.quit()
-
-
-def generic_error_cb(error):
-    print('D-Bus call failed: ' + str(error))
-    mainloop.quit()
-
-
-def int_to_uint16(value_in):
-    bin_string = '{:016b}'.format(value_in)
-    big_byte = int(bin_string[0:8], 2)
-    little_byte = int(bin_string[8:16], 2)
-    return [little_byte, big_byte]
-
-
-def sint16_to_int(bytes):
-    return int.from_bytes(bytes, byteorder='little', signed=True)
-
-
-def bytes_to_xyz(bytes):
-    x = sint16_to_int(bytes[0:2]) / 1000
-    y = sint16_to_int(bytes[2:4]) / 1000
-    z = sint16_to_int(bytes[4:6]) / 1000
-
-    return [x, y, z]
-
-
-def int_to_uint32(value_in):
-    bin_string = '{0:032b}'.format(value_in)
-    octet0 = int(bin_string[25:32], 2)
-    octet1 = int(bin_string[17:24], 2)
-    octet2 = int(bin_string[9:16], 2)
-    octet3 = int(bin_string[0:8], 2)
-
-    return [octet0, octet1, octet2,  octet3]

--- a/examples/microbit_poll.py
+++ b/examples/microbit_poll.py
@@ -1,7 +1,8 @@
 import time
 from bluezero import microbit
 
-ubit = microbit.Microbit(name='puteg')
+ubit = microbit.Microbit(adapter_addr='00:02:5B:03:44:07',
+                         device_addr='D4:AE:95:4C:3E:A4')
 
 ubit.connect()
 

--- a/run_local_tests.sh
+++ b/run_local_tests.sh
@@ -5,18 +5,18 @@ coverage run --append -m unittest -v tests.test_dbus_tools
 test1002=$?
 coverage run --append -m unittest -v tests.test_adapter
 test1003=$?
-coverage run --append -m unittest -v tests.test_device
+coverage run --append -m unittest -v tests.test_advertisement
 test1004=$?
-coverage run --append -m unittest -v tests.test_gatt
+coverage run --append -m unittest -v tests.test_device
 test1005=$?
+coverage run --append -m unittest -v tests.test_gatt
+test1006=$?
 coverage run --append -m unittest -v tests.test_broadcaster
 test101=$?
 coverage run --append -m unittest -v tests.test_central
 test102=$?
 coverage run --append -m unittest -v tests.test_peripheral
 test103=$?
-coverage run --append -m unittest -v tests.test_central
-test104=$?
 coverage run --append -m unittest -v tests.test_blinkt
 test11=$?
 coverage run --append -m unittest -v tests.test_eddystone
@@ -33,8 +33,8 @@ lint_examples=$?
 # lint_tests=$?
 
 coverage report
-group100=$((test1001 + test1002 + test1003 + test1004 + test1005))
-group10=$((test101 + test102 + test103 + test104))
+group100=$((test1001 + test1002 + test1003 + test1004 + test1005 + test1006))
+group10=$((test101 + test102 + test103))
 group1=$((test11 + test12 + test13))
 group_examples=$((test_example1))
 group_lint=$((lint_bluezero + lint_examples))

--- a/run_local_tests.sh
+++ b/run_local_tests.sh
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
 coverage run -m unittest -v tests.test_tools
 test1001=$?
-# python -m unittest -v tests.test_adapter
-# test21=$?
-coverage run --append -m unittest -v tests.test_adapter
+coverage run --append -m unittest -v tests.test_dbus_tools
 test1002=$?
-coverage run --append -m unittest -v tests.test_device
+coverage run --append -m unittest -v tests.test_adapter
 test1003=$?
-coverage run --append -m unittest -v tests.test_gatt
+coverage run --append -m unittest -v tests.test_device
 test1004=$?
+coverage run --append -m unittest -v tests.test_gatt
+test1005=$?
 coverage run --append -m unittest -v tests.test_broadcaster
 test101=$?
-coverage run --append -m unittest -v tests.test_peripheral
+coverage run --append -m unittest -v tests.test_central
 test102=$?
+coverage run --append -m unittest -v tests.test_peripheral
+test103=$?
+coverage run --append -m unittest -v tests.test_central
+test104=$?
 coverage run --append -m unittest -v tests.test_blinkt
 test11=$?
 coverage run --append -m unittest -v tests.test_eddystone
@@ -26,13 +30,13 @@ lint_bluezero=$?
 pycodestyle -v examples
 lint_examples=$?
 # pycodestyle -v tests
-# test53=$?
+# lint_tests=$?
 
 coverage report
-group100=$((test1001 + test1002 + test1003 + test1004))
-group10=$((test101 + test102))
+group100=$((test1001 + test1002 + test1003 + test1004 + test1005))
+group10=$((test101 + test102 + test103 + test104))
 group1=$((test11 + test12 + test13))
-group_exampels=$((test_example1))
+group_examples=$((test_example1))
 group_lint=$((lint_bluezero + lint_examples))
 if [ $((group1 + group10 + group100 + group_examples + group_lint)) -ne 0 ]; then
    echo -e "\n\n###  A test has failed!!  ###\n"

--- a/tests/obj_data.py
+++ b/tests/obj_data.py
@@ -1,1227 +1,1267 @@
 full_ubits = {
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c/char000d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a24-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.Device1': {
-                'Paired': False, 'LegacyPairing': False,
-                'Appearance': 512,
-                'Name': 'BBC micro:bit [vovev]',
-                'Alias': 'BBC micro:bit [vovev]', 'UUIDs': [
-                    '00001800-0000-1000-8000-00805f9b34fb',
-                    '00001801-0000-1000-8000-00805f9b34fb',
-                    '0000180a-0000-1000-8000-00805f9b34fb',
-                    'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                    'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                    'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                    'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                    'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                    'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
-                'Trusted': False, 'ServicesResolved': True,
-                'Connected': True,
-                'Adapter': '/org/bluez/hci0',
-                'Address': 'EB:F6:95:27:84:A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0032': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031',
-                'Notifying': False,
-                'UUID': 'e95dfb11-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0032/desc0034': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0032', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013/char0014/desc0016': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013/char0014', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a/char003b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a',
-                'Notifying': False,
-                'UUID': 'e95d9250-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95df2d8-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [0],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019',
-                'Notifying': False,
-                'UUID': 'e95dda90-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a/char002d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a',
-                'Flags': ['write'],
-                'UUID': 'e95d93ee-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0025': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020',
-                'Flags': ['write'],
-                'UUID': 'e95dd822-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95df2d8-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0025': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020',
-                'Flags': ['write'],
-                'UUID': 'e95dd822-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013/char0017': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95dfb24-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0032/desc0034': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0032', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c/char000f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a25-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0035': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031',
-                'Notifying': False,
-                'UUID': 'e95d9715-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0021': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d5899-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0035': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031',
-                'Notifying': False,
-                'UUID': 'e95d9715-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008/char0009/desc000b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008/char0009', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c/char000d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a24-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95df2d8-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008/char0009': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008',
-                'Notifying': False,
-                'UUID': '00002a05-0000-1000-8000-00805f9b34fb',
-                'Flags': ['indicate']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0027/desc0029': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0027', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0027/desc0029': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0027', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': '0000180a-0000-1000-8000-00805f9b34fb',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001a/desc001c': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001a', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0035/desc0037': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0035', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0027': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020',
-                'Notifying': False,
-                'UUID': 'e95d8d00-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'write', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a/char002b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d7b77-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0035': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031',
-                'Notifying': False,
-                'UUID': 'e95d9715-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': '00001801-0000-1000-8000-00805f9b34fb',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a/char003b/desc003d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a/char003b', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0035/desc0037': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0035', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': '0000180a-0000-1000-8000-00805f9b34fb',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013/char0014/desc0016': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013/char0014', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a/char002f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d0d2d-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019',
-                'Notifying': False,
-                'UUID': 'e95dda91-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0035/desc0037': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0035', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a/char003e': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d1b25-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_D4_AE_95_4C_3E_A4': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.Device1': {
-                'Paired': False, 'LegacyPairing': False,
-                'Appearance': 512,
-                'Name': 'BBC micro:bit [zezet]',
-                'Alias': 'BBC micro:bit [zezet]', 'UUIDs': [
-                    '00001800-0000-1000-8000-00805f9b34fb',
-                    '00001801-0000-1000-8000-00805f9b34fb',
-                    '0000180a-0000-1000-8000-00805f9b34fb',
-                    'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                    'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                    'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                    'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                    'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                    'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
-                'Trusted': False, 'ServicesResolved': False,
-                'Connected': False,
-                'Adapter': '/org/bluez/hci0',
-                'Address': 'D4:AE:95:4C:3E:A4'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c/char000d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a24-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013/char0014': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013',
-                'Notifying': False,
-                'UUID': 'e95dca4b-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0027': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020',
-                'Notifying': False,
-                'UUID': 'e95d8d00-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'write', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a/char002b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d7b77-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c/char0011': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a26-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0027/desc0029': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0027', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001a/desc001c': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001a', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0032': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031',
-                'Notifying': False,
-                'UUID': 'e95dfb11-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c/char000f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a25-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001a/desc001c': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001a', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c/char0011': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a26-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0025': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020',
-                'Flags': ['write'],
-                'UUID': 'e95dd822-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001d/desc001f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001d', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95df2d8-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0023': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95db9fe-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c/char0011': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a26-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a/char003b/desc003d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a/char003b', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019',
-                'Notifying': False,
-                'UUID': 'e95dda91-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c/char000d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a24-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0023': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95db9fe-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001a/desc001c': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001a', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013/char0014': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013',
-                'Notifying': False,
-                'UUID': 'e95dca4b-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a/char002f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d0d2d-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0032/desc0034': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0032', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a/char003b/desc003d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a/char003b', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019',
-                'Notifying': False,
-                'UUID': 'e95dda91-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a/char002b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d7b77-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [0],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019',
-                'Notifying': False,
-                'UUID': 'e95dda90-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0038': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d386c-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0038': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d386c-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a/char002f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d0d2d-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013/char0014': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013',
-                'Notifying': False,
-                'UUID': 'e95dca4b-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a/char002b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d7b77-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a/char002f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d0d2d-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattManager1': {},
-            'org.bluez.Adapter1': {
-                'Class': 4980736, 'Discovering': False, 'Pairable': True,
-                'PairableTimeout': 0, 'Powered': True, 'Alias': 'linaro-alip',
-                'UUIDs': ['00001112-0000-1000-8000-00805f9b34fb',
-                          '00001801-0000-1000-8000-00805f9b34fb',
-                          '0000110e-0000-1000-8000-00805f9b34fb',
-                          '0000112d-0000-1000-8000-00805f9b34fb',
-                          '00001800-0000-1000-8000-00805f9b34fb',
-                          '00001200-0000-1000-8000-00805f9b34fb',
-                          '0000110c-0000-1000-8000-00805f9b34fb',
-                          '0000110a-0000-1000-8000-00805f9b34fb',
-                          '0000110b-0000-1000-8000-00805f9b34fb'],
-                'Name': 'linaro-alip', 'Modalias': 'usb:v1D6Bp0246d052B',
-                'Address': '00:00:00:00:5A:AD', 'DiscoverableTimeout': 180,
-                'Discoverable': False},
-            'org.bluez.LEAdvertisingManager1': {},
-            'org.freedesktop.DBus.Introspectable': {},
-            'org.bluez.SimAccess1': {
-                'Connected': False},
-            'org.bluez.Media1': {},
-            'org.bluez.NetworkServer1': {}},
-        '/org/bluez': {
-            'org.bluez.AgentManager1': {},
-            'org.bluez.ProfileManager1': {},
-            'org.bluez.HealthManager1': {},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013/char0017': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95dfb24-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a/char003b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a',
-                'Notifying': False,
-                'UUID': 'e95d9250-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/test': {
-            'org.bluez.SimAccessTest1': {},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.Device1': {
-                'Paired': False, 'LegacyPairing': False,
-                'Appearance': 512,
-                'Name': 'BBC micro:bit [pugit]',
-                'Alias': 'BBC micro:bit [pugit]', 'UUIDs': [
-                    '00001800-0000-1000-8000-00805f9b34fb',
-                    '00001801-0000-1000-8000-00805f9b34fb',
-                    '0000180a-0000-1000-8000-00805f9b34fb',
-                    'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                    'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                    'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                    'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                    'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                    'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
-                'Trusted': False, 'ServicesResolved': True,
-                'Connected': True,
-                'Adapter': '/org/bluez/hci0',
-                'Address': 'E4:43:33:7E:54:1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0035': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031',
-                'Notifying': False,
-                'UUID': 'e95d9715-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0021': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d5899-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008/char0009/desc000b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008/char0009', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013/char0017': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95dfb24-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': '0000180a-0000-1000-8000-00805f9b34fb',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008/char0009/desc000b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008/char0009', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a/char002d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a',
-                'Flags': ['write'],
-                'UUID': 'e95d93ee-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a/char003e': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d1b25-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008/char0009': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008',
-                'Notifying': False,
-                'UUID': '00002a05-0000-1000-8000-00805f9b34fb',
-                'Flags': ['indicate']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001d/desc001f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001d', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a/char003e': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d1b25-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [0],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019',
-                'Notifying': False,
-                'UUID': 'e95dda90-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a/char003b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a',
-                'Notifying': False,
-                'UUID': 'e95d9250-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a/char002d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a',
-                'Flags': ['write'],
-                'UUID': 'e95d93ee-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0038': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d386c-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0025': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020',
-                'Flags': ['write'],
-                'UUID': 'e95dd822-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0027': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020',
-                'Notifying': False,
-                'UUID': 'e95d8d00-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'write', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': '00001801-0000-1000-8000-00805f9b34fb',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013/char0017': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95dfb24-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0023': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95db9fe-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': '00001801-0000-1000-8000-00805f9b34fb',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013/char0014': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013',
-                'Notifying': False,
-                'UUID': 'e95dca4b-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0032': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031',
-                'Notifying': False,
-                'UUID': 'e95dfb11-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013/char0014/desc0016': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013/char0014', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013/char0014/desc0016': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013/char0014', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0027': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020',
-                'Notifying': False,
-                'UUID': 'e95d8d00-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'write', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0027/desc0029': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0027', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0035/desc0037': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0035', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008/char0009/desc000b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008/char0009', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a/char003e': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d1b25-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': '00001801-0000-1000-8000-00805f9b34fb',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0023': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95db9fe-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c/char0011': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a26-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c/char000f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a25-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001d/desc001f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001d', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008/char0009': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008',
-                'Notifying': False,
-                'UUID': '00002a05-0000-1000-8000-00805f9b34fb',
-                'Flags': ['indicate']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0032': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031',
-                'Notifying': False,
-                'UUID': 'e95dfb11-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008/char0009': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008',
-                'Notifying': False,
-                'UUID': '00002a05-0000-1000-8000-00805f9b34fb',
-                'Flags': ['indicate']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0021': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d5899-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': 'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a/char003b/desc003d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a/char003b', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a/char003b': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a',
-                'Notifying': False,
-                'UUID': 'e95d9250-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattService1': {
-                'UUID': '0000180a-0000-1000-8000-00805f9b34fb',
-                'Primary': True,
-                'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001d/desc001f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001d', 'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.Device1': {
-                'Paired': False, 'LegacyPairing': False,
-                'Appearance': 512,
-                'Name': 'BBC micro:bit [pivug]',
-                'Alias': 'BBC micro:bit [pivug]', 'UUIDs': [
-                    '00001800-0000-1000-8000-00805f9b34fb',
-                    '00001801-0000-1000-8000-00805f9b34fb',
-                    '0000180a-0000-1000-8000-00805f9b34fb',
-                    'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                    'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                    'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                    'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                    'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                    'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
-                'Trusted': False, 'ServicesResolved': True,
-                'Connected': True,
-                'Adapter': '/org/bluez/hci0',
-                'Address': 'FD:6B:11:CD:4A:9B'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0032/desc0034': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattDescriptor1': {
-                'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0032',
-                'Value': [],
-                'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0038': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d386c-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.Device1': {
-                'Paired': False, 'LegacyPairing': False,
-                'Appearance': 512,
-                'Name': 'BBC micro:bit [puteg]',
-                'Alias': 'BBC micro:bit [puteg]', 'UUIDs': [
-                    '00001800-0000-1000-8000-00805f9b34fb',
-                    '00001801-0000-1000-8000-00805f9b34fb',
-                    '0000180a-0000-1000-8000-00805f9b34fb',
-                    'e95d0753-251d-470a-a062-fa1922dfa9a8',
-                    'e95d127b-251d-470a-a062-fa1922dfa9a8',
-                    'e95d6100-251d-470a-a062-fa1922dfa9a8',
-                    'e95d9882-251d-470a-a062-fa1922dfa9a8',
-                    'e95dd91d-251d-470a-a062-fa1922dfa9a8',
-                    'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
-                'Trusted': False, 'ServicesResolved': True,
-                'Connected': True,
-                'Adapter': '/org/bluez/hci0',
-                'Address': 'F7:17:E4:09:C0:C6'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0021': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020',
-                'Flags': ['read', 'write'],
-                'UUID': 'e95d5899-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a/char002d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a',
-                'Flags': ['write'],
-                'UUID': 'e95d93ee-251d-470a-a062-fa1922dfa9a8'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c/char000f': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c',
-                'Flags': ['read'],
-                'UUID': '00002a25-0000-1000-8000-00805f9b34fb'},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001d': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [],
-                'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019',
-                'Notifying': False,
-                'UUID': 'e95dda91-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}},
-        '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001a': {
-            'org.freedesktop.DBus.Properties': {},
-            'org.bluez.GattCharacteristic1': {
-                'Value': [0],
-                'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019',
-                'Notifying': False,
-                'UUID': 'e95dda90-251d-470a-a062-fa1922dfa9a8',
-                'Flags': ['read', 'notify']},
-            'org.freedesktop.DBus.Introspectable': {}}}
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c/char000d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a24-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.Device1': {
+            'Paired': False, 'LegacyPairing': False,
+            'Appearance': 512,
+            'Name': 'BBC micro:bit [vovev]',
+            'Alias': 'BBC micro:bit [vovev]', 'UUIDs': [
+                '00001800-0000-1000-8000-00805f9b34fb',
+                '00001801-0000-1000-8000-00805f9b34fb',
+                '0000180a-0000-1000-8000-00805f9b34fb',
+                'e95d0753-251d-470a-a062-fa1922dfa9a8',
+                'e95d127b-251d-470a-a062-fa1922dfa9a8',
+                'e95d6100-251d-470a-a062-fa1922dfa9a8',
+                'e95d9882-251d-470a-a062-fa1922dfa9a8',
+                'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+                'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
+            'Trusted': False, 'ServicesResolved': True,
+            'Connected': True,
+            'Adapter': '/org/bluez/hci0',
+            'Address': 'EB:F6:95:27:84:A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0032': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031',
+            'Notifying': False,
+            'UUID': 'e95dfb11-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0032/desc0034': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0032', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013/char0014/desc0016': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013/char0014', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a/char003b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a',
+            'Notifying': False,
+            'UUID': 'e95d9250-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95df2d8-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [0],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019',
+            'Notifying': False,
+            'UUID': 'e95dda90-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a/char002d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a',
+            'Flags': ['write'],
+            'UUID': 'e95d93ee-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0025': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020',
+            'Flags': ['write'],
+            'UUID': 'e95dd822-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95df2d8-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0025': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020',
+            'Flags': ['write'],
+            'UUID': 'e95dd822-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013/char0017': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95dfb24-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d0753-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d0753-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0032/desc0034': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0032', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d0753-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c/char000f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a25-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d9882-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0035': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031',
+            'Notifying': False,
+            'UUID': 'e95d9715-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0021': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d5899-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0035': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031',
+            'Notifying': False,
+            'UUID': 'e95d9715-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008/char0009/desc000b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008/char0009', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c/char000d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a24-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d127b-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95df2d8-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008/char0009': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008',
+            'Notifying': False,
+            'UUID': '00002a05-0000-1000-8000-00805f9b34fb',
+            'Flags': ['indicate']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0027/desc0029': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0027', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0027/desc0029': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0027', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d6100-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '0000180a-0000-1000-8000-00805f9b34fb',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001a/desc001c': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001a', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0035/desc0037': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0035', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0027': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020',
+            'Notifying': False,
+            'UUID': 'e95d8d00-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'write', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d127b-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a/char002b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d7b77-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0035': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031',
+            'Notifying': False,
+            'UUID': 'e95d9715-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '00001801-0000-1000-8000-00805f9b34fb',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a/char003b/desc003d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a/char003b', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0035/desc0037': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0035', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '0000180a-0000-1000-8000-00805f9b34fb',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013/char0014/desc0016': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013/char0014', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a/char002f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d0d2d-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019',
+            'Notifying': False,
+            'UUID': 'e95dda91-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0035/desc0037': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0035', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a/char003e': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d1b25-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_D4_AE_95_4C_3E_A4': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.Device1': {
+            'Paired': False, 'LegacyPairing': False,
+            'Appearance': 512,
+            'Name': 'BBC micro:bit [zezet]',
+            'Alias': 'BBC micro:bit [zezet]', 'UUIDs': [
+                '00001800-0000-1000-8000-00805f9b34fb',
+                '00001801-0000-1000-8000-00805f9b34fb',
+                '0000180a-0000-1000-8000-00805f9b34fb',
+                'e95d0753-251d-470a-a062-fa1922dfa9a8',
+                'e95d127b-251d-470a-a062-fa1922dfa9a8',
+                'e95d6100-251d-470a-a062-fa1922dfa9a8',
+                'e95d9882-251d-470a-a062-fa1922dfa9a8',
+                'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+                'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
+            'Trusted': False, 'ServicesResolved': False,
+            'Connected': False,
+            'Adapter': '/org/bluez/hci0',
+            'Address': 'D4:AE:95:4C:3E:A4'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c/char000d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a24-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013/char0014': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013',
+            'Notifying': False,
+            'UUID': 'e95dca4b-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0027': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020',
+            'Notifying': False,
+            'UUID': 'e95d8d00-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'write', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a/char002b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d7b77-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c/char0011': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a26-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0027/desc0029': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0027', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001a/desc001c': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001a', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0032': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031',
+            'Notifying': False,
+            'UUID': 'e95dfb11-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c/char000f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a25-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001a/desc001c': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001a', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c/char0011': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a26-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0025': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020',
+            'Flags': ['write'],
+            'UUID': 'e95dd822-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001d/desc001f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001d', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d6100-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95df2d8-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0023': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95db9fe-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c/char0011': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a26-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a/char003b/desc003d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a/char003b', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019',
+            'Notifying': False,
+            'UUID': 'e95dda91-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c/char000d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a24-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020/char0023': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95db9fe-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0020': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d127b-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001a/desc001c': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001a', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013/char0014': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0013',
+            'Notifying': False,
+            'UUID': 'e95dca4b-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a/char002f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d0d2d-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0032/desc0034': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0032', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a/char003b/desc003d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service003a/char003b', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019',
+            'Notifying': False,
+            'UUID': 'e95dda91-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d6100-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d6100-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a/char002b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d7b77-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [0],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019',
+            'Notifying': False,
+            'UUID': 'e95dda90-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0038': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d386c-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031/char0038': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0031',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d386c-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a/char002f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d0d2d-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d9882-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013/char0014': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013',
+            'Notifying': False,
+            'UUID': 'e95dca4b-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a/char002b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d7b77-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a/char002f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d0d2d-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattManager1': {},
+        'org.bluez.Adapter1': {
+            'Class': 4980736, 'Discovering': False, 'Pairable': True,
+            'PairableTimeout': 0, 'Powered': True, 'Alias': 'linaro-alip',
+            'UUIDs': ['00001112-0000-1000-8000-00805f9b34fb',
+                      '00001801-0000-1000-8000-00805f9b34fb',
+                      '0000110e-0000-1000-8000-00805f9b34fb',
+                      '0000112d-0000-1000-8000-00805f9b34fb',
+                      '00001800-0000-1000-8000-00805f9b34fb',
+                      '00001200-0000-1000-8000-00805f9b34fb',
+                      '0000110c-0000-1000-8000-00805f9b34fb',
+                      '0000110a-0000-1000-8000-00805f9b34fb',
+                      '0000110b-0000-1000-8000-00805f9b34fb'],
+            'Name': 'linaro-alip', 'Modalias': 'usb:v1D6Bp0246d052B',
+            'Address': '00:00:00:00:5A:AD', 'DiscoverableTimeout': 180,
+            'Discoverable': False},
+        'org.bluez.LEAdvertisingManager1': {},
+        'org.freedesktop.DBus.Introspectable': {},
+        'org.bluez.SimAccess1': {
+            'Connected': False},
+        'org.bluez.Media1': {},
+        'org.bluez.NetworkServer1': {}},
+    '/org/bluez': {
+        'org.bluez.AgentManager1': {},
+        'org.bluez.ProfileManager1': {},
+        'org.bluez.HealthManager1': {},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013/char0017': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95dfb24-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a/char003b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a',
+            'Notifying': False,
+            'UUID': 'e95d9250-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/test': {
+        'org.bluez.SimAccessTest1': {},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_B1': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.Device1': {
+            'Paired': False, 'LegacyPairing': False,
+            'Appearance': 512,
+            'Name': 'Blinkt Lights',
+            'Alias': 'Blinkt Lights Controller',
+            'UUIDs': [
+                '00001800-0000-1000-8000-00805f9b34fb',
+                '00001801-0000-1000-8000-00805f9b34fb',
+                '0000180a-0000-1000-8000-00805f9b34fb',
+                'e95d0753-251d-470a-a062-fa1922dfa9a8',
+                'e95d127b-251d-470a-a062-fa1922dfa9a8',
+                'e95d6100-251d-470a-a062-fa1922dfa9a8',
+                'e95d9882-251d-470a-a062-fa1922dfa9a8',
+                'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+                'e95df2d8-251d-470a-a062-fa1922dfa9a8'],
+            'Blocked': False,
+            'Trusted': False,
+            'ServicesResolved': True,
+            'Connected': True,
+            'Adapter': '/org/bluez/hci0',
+            'Address': 'E4:43:33:7E:54:B1'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_B1/service0031': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '0000FFF0-0000-1000-8000-00805F9B34FB',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_B1'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_B1/service0031/char0035': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_B1/service0031',
+            'Notifying': False,
+            'UUID': '0000FFF3-0000-1000-8000-00805F9B34FB',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.Device1': {
+            'Paired': False, 'LegacyPairing': False,
+            'Appearance': 512,
+            'Name': 'BBC micro:bit [pugit]',
+            'Alias': 'BBC micro:bit [pugit]', 'UUIDs': [
+                '00001800-0000-1000-8000-00805f9b34fb',
+                '00001801-0000-1000-8000-00805f9b34fb',
+                '0000180a-0000-1000-8000-00805f9b34fb',
+                'e95d0753-251d-470a-a062-fa1922dfa9a8',
+                'e95d127b-251d-470a-a062-fa1922dfa9a8',
+                'e95d6100-251d-470a-a062-fa1922dfa9a8',
+                'e95d9882-251d-470a-a062-fa1922dfa9a8',
+                'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+                'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
+            'Trusted': False, 'ServicesResolved': True,
+            'Connected': True,
+            'Adapter': '/org/bluez/hci0',
+            'Address': 'E4:43:33:7E:54:1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0035': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031',
+            'Notifying': False,
+            'UUID': 'e95d9715-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0021': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d5899-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008/char0009/desc000b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008/char0009', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013/char0017': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95dfb24-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d127b-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service000c': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '0000180a-0000-1000-8000-00805f9b34fb',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008/char0009/desc000b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008/char0009', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a/char002d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a',
+            'Flags': ['write'],
+            'UUID': 'e95d93ee-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a/char003e': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service003a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d1b25-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008/char0009': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008',
+            'Notifying': False,
+            'UUID': '00002a05-0000-1000-8000-00805f9b34fb',
+            'Flags': ['indicate']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001d/desc001f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001d', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a/char003e': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d1b25-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019/char001a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [0],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0019',
+            'Notifying': False,
+            'UUID': 'e95dda90-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a/char003b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a',
+            'Notifying': False,
+            'UUID': 'e95d9250-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a/char002d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a',
+            'Flags': ['write'],
+            'UUID': 'e95d93ee-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0038': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d386c-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0025': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020',
+            'Flags': ['write'],
+            'UUID': 'e95dd822-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0027': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020',
+            'Notifying': False,
+            'UUID': 'e95d8d00-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'write', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0008': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '00001801-0000-1000-8000-00805f9b34fb',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013/char0017': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95dfb24-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0023': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95db9fe-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0008': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '00001801-0000-1000-8000-00805f9b34fb',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013/char0014': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013',
+            'Notifying': False,
+            'UUID': 'e95dca4b-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0032': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031',
+            'Notifying': False,
+            'UUID': 'e95dfb11-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d9882-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d9882-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013/char0014/desc0016': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0013/char0014', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013/char0014/desc0016': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0013/char0014', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0027': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020',
+            'Notifying': False,
+            'UUID': 'e95d8d00-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'write', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0027/desc0029': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0027', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0035/desc0037': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0035', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008/char0009/desc000b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008/char0009', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a/char003e': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d1b25-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '00001801-0000-1000-8000-00805f9b34fb',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020/char0023': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0020',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95db9fe-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c/char0011': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a26-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c/char000f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a25-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001d/desc001f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0019/char001d', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008/char0009': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0008',
+            'Notifying': False,
+            'UUID': '00002a05-0000-1000-8000-00805f9b34fb',
+            'Flags': ['indicate']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031/char0032': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0031',
+            'Notifying': False,
+            'UUID': 'e95dfb11-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008/char0009': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0008',
+            'Notifying': False,
+            'UUID': '00002a05-0000-1000-8000-00805f9b34fb',
+            'Flags': ['indicate']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020/char0021': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0020',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d5899-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0013': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': 'e95d0753-251d-470a-a062-fa1922dfa9a8',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a/char003b/desc003d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service003a/char003b', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a/char003b': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service003a',
+            'Notifying': False,
+            'UUID': 'e95d9250-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service000c': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattService1': {
+            'UUID': '0000180a-0000-1000-8000-00805f9b34fb',
+            'Primary': True,
+            'Device': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001d/desc001f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001d', 'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.Device1': {
+            'Paired': False, 'LegacyPairing': False,
+            'Appearance': 512,
+            'Name': 'BBC micro:bit [pivug]',
+            'Alias': 'BBC micro:bit [pivug]', 'UUIDs': [
+                '00001800-0000-1000-8000-00805f9b34fb',
+                '00001801-0000-1000-8000-00805f9b34fb',
+                '0000180a-0000-1000-8000-00805f9b34fb',
+                'e95d0753-251d-470a-a062-fa1922dfa9a8',
+                'e95d127b-251d-470a-a062-fa1922dfa9a8',
+                'e95d6100-251d-470a-a062-fa1922dfa9a8',
+                'e95d9882-251d-470a-a062-fa1922dfa9a8',
+                'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+                'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
+            'Trusted': False, 'ServicesResolved': True,
+            'Connected': True,
+            'Adapter': '/org/bluez/hci0',
+            'Address': 'FD:6B:11:CD:4A:9B'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0032/desc0034': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattDescriptor1': {
+            'Characteristic': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0031/char0032',
+            'Value': [],
+            'UUID': '00002902-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031/char0038': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service0031',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d386c-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.Device1': {
+            'Paired': False, 'LegacyPairing': False,
+            'Appearance': 512,
+            'Name': 'BBC micro:bit [puteg]',
+            'Alias': 'BBC micro:bit [puteg]', 'UUIDs': [
+                '00001800-0000-1000-8000-00805f9b34fb',
+                '00001801-0000-1000-8000-00805f9b34fb',
+                '0000180a-0000-1000-8000-00805f9b34fb',
+                'e95d0753-251d-470a-a062-fa1922dfa9a8',
+                'e95d127b-251d-470a-a062-fa1922dfa9a8',
+                'e95d6100-251d-470a-a062-fa1922dfa9a8',
+                'e95d9882-251d-470a-a062-fa1922dfa9a8',
+                'e95dd91d-251d-470a-a062-fa1922dfa9a8',
+                'e95df2d8-251d-470a-a062-fa1922dfa9a8'], 'Blocked': False,
+            'Trusted': False, 'ServicesResolved': True,
+            'Connected': True,
+            'Adapter': '/org/bluez/hci0',
+            'Address': 'F7:17:E4:09:C0:C6'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020/char0021': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service0020',
+            'Flags': ['read', 'write'],
+            'UUID': 'e95d5899-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a/char002d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a',
+            'Flags': ['write'],
+            'UUID': 'e95d93ee-251d-470a-a062-fa1922dfa9a8'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c/char000f': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service000c',
+            'Flags': ['read'],
+            'UUID': '00002a25-0000-1000-8000-00805f9b34fb'},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019/char001d': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [],
+            'Service': '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service0019',
+            'Notifying': False,
+            'UUID': 'e95dda91-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}},
+    '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019/char001a': {
+        'org.freedesktop.DBus.Properties': {},
+        'org.bluez.GattCharacteristic1': {
+            'Value': [0],
+            'Service': '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service0019',
+            'Notifying': False,
+            'UUID': 'e95dda90-251d-470a-a062-fa1922dfa9a8',
+            'Flags': ['read', 'notify']},
+        'org.freedesktop.DBus.Introspectable': {}}}

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -4,8 +4,6 @@ from unittest.mock import patch
 import tests.obj_data
 from bluezero import constants
 
-adapter_props = tests.obj_data.full_ubits
-
 
 def mock_get(iface, prop):
     return tests.obj_data.full_ubits['/org/bluez/hci0'][iface][prop]

--- a/tests/test_advertisement.py
+++ b/tests/test_advertisement.py
@@ -48,9 +48,9 @@ class TestBluezeroAdvertisement(unittest.TestCase):
         self.module_patcher = patch.dict('sys.modules', modules)
         self.module_patcher.start()
         from bluezero import advertisement
-        from bluezero import tools
+        from bluezero import dbus_tools
         self.module_under_test = advertisement
-        self.module_tools = tools
+        self.module_tools = dbus_tools
 
     def tearDown(self):
         self.module_patcher.stop()

--- a/tests/test_blinkt.py
+++ b/tests/test_blinkt.py
@@ -2,11 +2,14 @@ import unittest
 from unittest.mock import MagicMock
 from unittest.mock import patch
 import tests.obj_data
-from bluezero import constants
-
 
 def mock_get(iface, prop):
-    return tests.obj_data.full_ubits['/org/bluez/hci0'][iface][prop]
+    if iface == 'org.bluez.Device1':
+        return tests.obj_data.full_ubits['/org/bluez/hci0/dev_E4_43_33_7E_54_B1'][iface][prop]
+    elif iface == 'org.bluez.Adapter1':
+        return tests.obj_data.full_ubits['/org/bluez/hci0'][iface][prop]
+    elif iface == 'org.bluez.Characteristic1':
+        return tests.obj_data.full_ubits['/org/bluez/hci0/dev_E4_43_33_7E_54_B1/service0031/char0035'][iface][prop]
 
 
 def mock_set(iface, prop, value):
@@ -46,4 +49,7 @@ class TestBluezeroBlinkt(unittest.TestCase):
         self.module_patcher.stop()
 
     def test_load(self):
-        my_blinkt = self.module_under_test.BLE_blinkt(name='BBC micro:bit [puteg]')
+        my_blinkt = self.module_under_test.BLE_blinkt(adapter_addr='00:00:00:00:5A:AD',
+                                                      device_addr='E4:43:33:7E:54:B1')
+
+        self.assertEqual(my_blinkt.connected, True)

--- a/tests/test_central.py
+++ b/tests/test_central.py
@@ -10,7 +10,9 @@ adapter_props = tests.obj_data.full_ubits
 
 
 def mock_get(iface, prop):
-    if iface == 'org.bluez.Device1':
+    if iface == 'org.bluez.Adapter1':
+        return tests.obj_data.full_ubits['/org/bluez/hci0'][iface][prop]
+    elif iface == 'org.bluez.Device1':
         return tests.obj_data.full_ubits['/org/bluez/hci0/dev_E4_43_33_7E_54_1C'][iface][prop]
     else:
         return tests.obj_data.full_ubits['/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a'][iface][prop]
@@ -20,8 +22,8 @@ def mock_set(iface, prop, value):
     tests.obj_data.full_ubits['/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a'][iface][prop] = value
 
 
-class TestBluezeroService(unittest.TestCase):
-    """Test class to exercise (remote) GATT Service Features."""
+class TestBluezeroCentral(unittest.TestCase):
+    """Test class to exercise Central Features."""
 
     def setUp(self):
         """Initialise the class for the tests."""
@@ -39,8 +41,8 @@ class TestBluezeroService(unittest.TestCase):
         self.dbus_mock.Interface.return_value.Set = mock_set
         self.module_patcher = patch.dict('sys.modules', modules)
         self.module_patcher.start()
-        from bluezero import GATT
-        self.module_under_test = GATT
+        from bluezero import central
+        self.module_under_test = central
         self.path = '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a'
         self.adapter_path = '/org/bluez/hci0'
         self.dev_name = 'BBC micro:bit [zezet]'
@@ -52,39 +54,10 @@ class TestBluezeroService(unittest.TestCase):
         self.module_patcher.stop()
 
     def test_service_uuid(self):
-        """Test the service UUID."""
+        """Test the central instantiation."""
         # Invoke the bluez GATT library to access the mock GATT service
-        test_service = self.module_under_test.Service(self.adapter_addr,
-                                                      self.device_addr,
-                                                      self.service_uuid)
+        test_central = self.module_under_test.Central(adapter_addr=self.adapter_addr,
+                                                      device_addr=self.device_addr)
 
         # Test for the UUID
-        self.assertEqual(test_service.UUID, 'e95dd91d-251d-470a-a062-fa1922dfa9a8')
-
-    def test_service_device(self):
-        """Test the service device path."""
-        # Invoke the bluez GATT library to access the mock GATT service
-        test_service = self.module_under_test.Service(self.adapter_addr,
-                                                      self.device_addr,
-                                                      self.service_uuid)
-
-        # Test for the device path
-        dev_underscore = self.device_addr.replace(':', '_').upper()
-        dev_addr = '{0}/dev_{1}'.format(self.adapter_path, dev_underscore)
-        self.assertEqual(test_service.device, dev_addr)
-
-    def test_service_primary(self):
-        """Test the service primary flag."""
-        # Invoke the bluez GATT library to access the mock GATT service
-        test_service = self.module_under_test.Service(self.adapter_addr,
-                                                      self.device_addr,
-                                                      self.service_uuid)
-
-        # Test for the UUID
-        self.assertEqual(test_service.primary, True)
-
-
-if __name__ == '__main__':
-    # avoid writing to stderr
-    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout,
-                                                     verbosity=2))
+        self.assertEqual(test_central.connected, True)

--- a/tests/test_dbus_tools.py
+++ b/tests/test_dbus_tools.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+import tests.obj_data
+from bluezero import constants
+
+
+class TestDbusModuleCalls(unittest.TestCase):
+    """
+    Testing things that use the Dbus module
+    """
+    def setUp(self):
+        """
+        Patch the DBus module
+        :return:
+        """
+        self.dbus_mock = MagicMock()
+        self.mainloop_mock = MagicMock()
+        self.gobject_mock = MagicMock()
+
+        modules = {
+            'dbus': self.dbus_mock,
+            'dbus.mainloop.glib': self.mainloop_mock,
+            'gi.repository': self.gobject_mock,
+        }
+        self.dbus_mock.Interface.return_value.GetManagedObjects.return_value = tests.obj_data.full_ubits
+        self.module_patcher = patch.dict('sys.modules', modules)
+        self.module_patcher.start()
+        from bluezero import dbus_tools
+        self.module_under_test = dbus_tools
+
+    def tearDown(self):
+        self.module_patcher.stop()
+
+    def test_uuid_path_gatt(self):
+        dbus_gatt_path = self.module_under_test.uuid_dbus_path(constants.GATT_SERVICE_IFACE,
+                                                               'e95dd91d-251d-470a-a062-fa1922dfa9a8')
+        expected_result = ['/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a',
+                           '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a',
+                           '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a',
+                           '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a']
+        self.assertCountEqual(dbus_gatt_path, expected_result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -39,17 +39,18 @@ class TestBluezeroDevice(unittest.TestCase):
         self.path = '/org/bluez/hci0/dev_D4_AE_95_4C_3E_A4'
         self.adapter_path = '/org/bluez/hci0'
         self.dev_name = 'BBC micro:bit [zezet]'
-        self.address = 'D4:AE:95:4C:3E:A4'
+        self.adapter_addr = '00:00:00:00:5A:AD'
+        self.device_addr = 'D4:AE:95:4C:3E:A4'
 
     def tearDown(self):
         self.module_patcher.stop()
 
     def test_device_name(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.name, self.dev_name)
 
     def test_connected(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         conn_state = ble_dev.connected
         self.assertEqual(conn_state, False)
         """
@@ -59,11 +60,11 @@ class TestBluezeroDevice(unittest.TestCase):
         self.assertEqual(conn_state, True)
     """
     def test_address(self):
-        ble_dev = self.module_under_test.Device(self.path)
-        self.assertEqual(ble_dev.address, self.address)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
+        self.assertEqual(ble_dev.address, self.device_addr)
 
     def test_name(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.name, self.dev_name)
 
     @unittest.skip('Do not know value to use for icon')
@@ -75,11 +76,11 @@ class TestBluezeroDevice(unittest.TestCase):
         pass
 
     def test_appearance(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.appearance, 0x0200)
 
     def test_uuids(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.uuids,
                          ['00001800-0000-1000-8000-00805f9b34fb',
                           '00001801-0000-1000-8000-00805f9b34fb',
@@ -92,27 +93,27 @@ class TestBluezeroDevice(unittest.TestCase):
                           'e95df2d8-251d-470a-a062-fa1922dfa9a8'])
 
     def test_paired(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.paired, False)
 
     def test_trusted(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.trusted, False)
 
     def test_blocked(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.blocked, False)
 
     def test_alias(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.alias, self.dev_name)
 
     def test_adapter(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.adapter, self.adapter_path)
 
     def test_legacy_pairing(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.legacy_pairing, False)
 
     @unittest.skip('Do not know value to use for modalias')
@@ -121,12 +122,12 @@ class TestBluezeroDevice(unittest.TestCase):
 
     @unittest.skip('No value from BlueZ for RSSI')
     def test_rssi(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.RSSI, -79)
 
     @unittest.skip('No value from BlueZ for Tx Power')
     def test_txpower(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.tx_power, 0)
 
     @unittest.skip('Do not know value to use for manufacturer data')
@@ -138,7 +139,7 @@ class TestBluezeroDevice(unittest.TestCase):
         pass
 
     def test_services_resolved(self):
-        ble_dev = self.module_under_test.Device(self.path)
+        ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.services_resolved, False)
 
     @unittest.skip('Not in BlueZ 5.42')

--- a/tests/test_microbit.py
+++ b/tests/test_microbit.py
@@ -6,7 +6,12 @@ from bluezero import constants
 
 
 def mock_get(iface, prop):
-    return tests.obj_data.full_ubits['/org/bluez/hci0'][iface][prop]
+    if iface == 'org.bluez.Device1':
+        return tests.obj_data.full_ubits['/org/bluez/hci0/dev_E4_43_33_7E_54_1C'][iface][prop]
+    elif iface == 'org.bluez.Adapter1':
+        return tests.obj_data.full_ubits['/org/bluez/hci0'][iface][prop]
+    elif iface == 'org.bluez.Characteristic1':
+        return tests.obj_data.full_ubits['/org/bluez/hci0/dev_E4_43_33_7E_54_B1/service0031/char0035'][iface][prop]
 
 
 def mock_set(iface, prop, value):
@@ -46,4 +51,5 @@ class TestBluezeroMicrobit(unittest.TestCase):
         self.module_patcher.stop()
 
     def test_load(self):
-        my_blinkt = self.module_under_test.Microbit(name='BBC micro:bit [puteg]')
+        ubit = self.module_under_test.Microbit(adapter_addr='00:00:00:00:5A:AD',
+                                               device_addr='E4:43:33:7E:54:1C')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -61,14 +61,5 @@ class TestDbusModuleCalls(unittest.TestCase):
         little_endian = self.module_under_test.int_to_uint32(305419896)
         self.assertListEqual(little_endian, [0x78, 0x56, 0x34, 0x12])
 
-    def test_uuid_path_gatt(self):
-        dbus_gatt_path = self.module_under_test.uuid_dbus_path(constants.GATT_SERVICE_IFACE,
-                                                               'e95dd91d-251d-470a-a062-fa1922dfa9a8')
-        expected_result = ['/org/bluez/hci0/dev_FD_6B_11_CD_4A_9B/service002a',
-                           '/org/bluez/hci0/dev_F7_17_E4_09_C0_C6/service002a',
-                           '/org/bluez/hci0/dev_EB_F6_95_27_84_A0/service002a',
-                           '/org/bluez/hci0/dev_E4_43_33_7E_54_1C/service002a']
-        self.assertCountEqual(dbus_gatt_path, expected_result)
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is quick a big change that breaks some of the existing API however
we are still pre 1.0.0 on this library and these are the kind of things
we are trying to get right before going to a fix release.
To aid this I’ve created the central.py file which has greatly
simplified the level 1 files like microbit.py and blinkt.py
closes #140 #138 #137