### PR TITLE
Fix default Adapter Initialisation

### DIFF
--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -89,11 +89,11 @@ class Adapter:
         self.bus = dbus.SystemBus()
 
         if adapter_addr is None:
-            adapters = dbus_tools.list_adapters()
+            adapters = list_adapters()
             if len(adapters) > 0:
-                adapter_addr = adapters[0]
-
-        self.path = dbus_tools.get_dbus_path(adapter=adapter_addr)
+                self.path = adapters[0]
+        else:
+            self.path = dbus_tools.get_dbus_path(adapter=adapter_addr)
         self.adapter_object = self.bus.get_object(
             constants.BLUEZ_SERVICE_NAME,
             self.path)

--- a/bluezero/central.py
+++ b/bluezero/central.py
@@ -30,14 +30,14 @@ class Central:
 
     def __init__(self, device_addr, adapter_addr=None):
         if adapter_addr is None:
-            self.dongle = adapter.Adapter(adapter.list_adapters()[0])
+            self.dongle = adapter.Adapter()
             logger.debug('Adapter is: {}'.format(self.dongle.address))
         else:
             self.dongle = adapter.Adapter(adapter_addr)
         if not self.dongle.powered:
             self.dongle.powered = True
             logger.debug('Adapter was off, now powered on')
-        self.rmt_device = device.Device(adapter_addr, device_addr)
+        self.rmt_device = device.Device(self.dongle.address, device_addr)
 
         self._characteristics = []
 

--- a/bluezero/dbus_tools.py
+++ b/bluezero/dbus_tools.py
@@ -224,7 +224,7 @@ def get_props(adapter=None,
                              characteristic,
                              descriptor)
 
-    return get_dbus_iface(dbus.PROPERTIES_IFACE, path_obj)
+    return get_dbus_iface(dbus.PROPERTIES_IFACE, get_dbus_obj(path_obj))
 
 
 #############################


### PR DESCRIPTION
- Default adapter initialisation is broken because `list_adapters()` produces a path rather than an address.  This was the most straightforward way I could see of doing it, although if `list_adapters()` needs to change then that's the other way.
- This then needed tweaking in the Central initialisation for cases with no set adapter address.
- `get_props` in `dbus_tools` needed to have its output wrapped in a `get_dbus_obj` to match the expected value when linking to a callback.