### PR TITLE
Mock dbus and gobject modules for readthedocs builds

### DIFF
--- a/bluezero/advertisement.py
+++ b/bluezero/advertisement.py
@@ -1,4 +1,6 @@
-"""Class and methods that represent LE Advertising.
+"""
+Class and methods that represent LE Advertising.
+This class requires BlueZ to have the experimental flag enabled
 
 Classes:
 
@@ -251,11 +253,13 @@ def register_ad_error_cb(error):
 
 
 class AdvertisingManager:
+    """
+    Associate the advertisement to an adapter.
+    If no adapter specified then first adapter in list is used
+    """
+
     def __init__(self, adapter_addr=None):
-        """
-        Associate the advertisement to an adapter.
-        If no adapter specified then first adapter in list is used
-        """
+
         self.bus = dbus.SystemBus()
 
         if adapter_addr is None:

--- a/bluezero/blinkt.py
+++ b/bluezero/blinkt.py
@@ -1,6 +1,7 @@
 """
 This is a simple API to access the Pimoroni Blinkt device.
-This is the central API. The peripheral is created with
+This is the central API.
+The peripheral is created with:
 examples/level100/blinkt_ble.py
 
 """
@@ -26,7 +27,8 @@ logger.addHandler(NullHandler())
 
 class BLE_blinkt:
     """
-    Class to simplify interacting with a microbit over Bluetooth Low Energy
+    Class to simplify interacting with a Pimoroni Blinkt over
+    Bluetooth Low Energy
     """
     def __init__(self, device_addr, adapter_addr=None):
         """

--- a/bluezero/broadcaster.py
+++ b/bluezero/broadcaster.py
@@ -1,5 +1,6 @@
 """
 The level 10 file for creating beacons
+This requires BlueZ to have the experimental flag set
 """
 from bluezero import adapter
 from bluezero import advertisement

--- a/bluezero/eddystone.py
+++ b/bluezero/eddystone.py
@@ -1,5 +1,12 @@
 """
 Level 1 file for creating Eddystone beacons
+
+Eddystone is a Bluetooth Low Energy beacon profile released by
+Google in July 2015
+https://github.com/google/eddystone
+
+This is the broadcaster role which currently requires BlueZ to
+have the experimental flag enabled
 """
 from bluezero import tools
 from bluezero import broadcaster
@@ -7,17 +14,18 @@ from bluezero import broadcaster
 
 class EddystoneURL:
     """
-    Eddystone is a Bluetooth Low Energy beacon profile released by
-    Google in July 2015
-    https://github.com/google/eddystone
+    Create and start broadcasting a Eddystone URL beacon
+
+    The Eddystone-URL frame broadcasts a URL using a compressed encoding
+    format in order to fit more within the limited advertisement packet.
+    :Example:
+
+    >>> from bluezero import eddystone
+    >>> eddystone.EddystoneURL('https://github.com/ukBaz')
+
     """
     def __init__(self, url, tx_power=0x08):
-        """The Eddystone-URL frame broadcasts a URL using a compressed encoding
-        format in order to fit more within the limited advertisement packet.
-        :Example:
-
-        >>> from bluezero import eddystone
-        >>> eddystone.EddystoneURL('https://github.com/ukBaz')
+        """
 
         :param url: String containing URL e.g. ('http://camjam.me')
         :param tx_power: Value of Tx Power of advertisement (Not implemented)

--- a/bluezero/microbit.py
+++ b/bluezero/microbit.py
@@ -343,6 +343,7 @@ class BitBot(Microbit):
     """
     Class to simplify interacting with a microbit attached to a bit:bot
     over Bluetooth Low Energy
+    The bit:bot is a micro:bit robot available from 4tronix.co.uk
     """
     def __init__(self, name=None, device_addr=None):
         """

--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -7,6 +7,8 @@ Current classes include:
 - Characteristic -- Bluetooth Characteristic
 - Descriptor -- Bluetooth Descriptor
 - Advertisement -- Bluetooth Advertisement
+
+This requires BlueZ to have the experimental flag to be enabled
 """
 
 # D-Bus imports

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,24 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
+from unittest.mock import MagicMock
+
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return MagicMock()
+
+MOCK_MODULES = ['dbus',
+                'dbus.service',
+                'dbus.exceptions',
+                'dbus.mainloop',
+                'dbus.mainloop.glib',
+                'gobject']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 sys.path.insert(0, os.path.abspath("../"))
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/level1.rst
+++ b/docs/level1.rst
@@ -7,6 +7,7 @@ Eddystone
 .. currentmodule:: bluezero.eddystone
 
 .. automodule:: bluezero.eddystone
+    :special-members:
     :members:
 
 micro:bit

--- a/docs/shared.rst
+++ b/docs/shared.rst
@@ -22,7 +22,7 @@ Constants
 DBus Tools
 ==========
 
-.. py:currentmodule:: bluezero.dbus_tools
+.. currentmodule:: bluezero.dbus_tools
 
 .. automodule:: bluezero.dbus_tools
     :members:


### PR DESCRIPTION
The auto documentation of modules was not working on readthedocs
because the Bluezero modules were not loading because of missing
modules on the build server. This has been fixed by mocking the dbus
and gobject modules in the conf.py file.
Some tidy-up of docstrings. Mainly because __init__ strings are not
output