### PR TITLE
Get cpu temperature on read

### DIFF
--- a/examples/cpu_temperature.py
+++ b/examples/cpu_temperature.py
@@ -69,6 +69,8 @@ class TemperatureChrc(localGATT.Characteristic):
         GObject.timeout_add(500, self.temperature_cb)
 
     def ReadValue(self, options):
+        reading = [get_cpu_temperature()]
+        self.props[constants.GATT_CHRC_IFACE]['Value'] = reading
         return dbus.Array(
             cpu_temp_sint16(self.props[constants.GATT_CHRC_IFACE]['Value'])
         )


### PR DESCRIPTION
This fixes a bug where the example only worked when you did notify. If
you just did a read then it return a previously read value.