### PR TITLE
Catch import error and using gobject as import

### DIFF
--- a/bluezero/async_tools.py
+++ b/bluezero/async_tools.py
@@ -1,5 +1,8 @@
 # Main eventloop import
-from gi.repository import GObject
+try:
+    from gi.repository import GObject
+except ImportError:
+    import gobject as GObject
 
 import logging
 try:  # Python 2.7+


### PR DESCRIPTION
This will catch an import error for gi.repository and use gobject instead, similar to the cpu_temperature.py example (https://github.com/ukBaz/python-bluezero/blob/master/examples/cpu_temperature.py).