### PR TITLE
Add miscellaneous functionalities

### DIFF
--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -256,6 +256,14 @@ class Adapter(object):
         """Stop scanning of nearby Bluetooth devices."""
         self.adapter_methods.StopDiscovery()
 
+    def remove_device(self, device_object):
+        """
+        Remove device from the actual adapter and clear pairing
+        info if it exists
+        :param device_object: device_remote_object
+        """
+        self.adapter_methods.RemoveDevice(device_object)
+
     def run(self):
         self.mainloop.run()
 

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -9,6 +9,7 @@ import dbus
 from bluezero import constants
 from bluezero import dbus_tools
 from bluezero import async_tools
+from bluezero import device
 
 import logging
 try:  # Python 2.7+
@@ -210,6 +211,18 @@ class Adapter:
             self.mainloop.quit()
             return False
         return True
+
+    def get_managed_device_list(self):
+        """Return a list of Devices manageable by this adapter"""
+        device_objects_list = []
+        managed_devices = dbus_tools.get_managed_objects()
+        for key, dev in managed_devices.items():
+            remote_device = dev.get("org.bluez.Device1")
+            if remote_device is not None:
+                device_addr = remote_device.get("Address")
+                if device_addr is not None:
+                    device_objects_list.append(device.Device(self.address, device_addr))
+        return device_objects_list
 
     def nearby_discovery(self, timeout=10):
         """Start discovery of nearby Bluetooth devices."""

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -221,6 +221,17 @@ class Adapter:
         self.adapter_methods.StartDiscovery()
         self.mainloop.run()
 
+    def nearby_discovery_async(self):
+        """
+        Start discovery of nearby Bluetooth devices.
+        :return: True on success otherwise False
+        """
+        try:
+            self.adapter_methods.StartDiscovery()
+            return True
+        except dbus.DBusException as e:
+            return False, e
+
     def stop_discovery(self):
         """Stop scanning of nearby Bluetooth devices."""
         self.adapter_methods.StopDiscovery()

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -49,7 +49,7 @@ def list_adapters():
         return addresses
 
 
-class Adapter:
+class Adapter(object):
     """Bluetooth Adapter Class.
 
     This class instantiates an object that interacts with the physical

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -212,6 +212,12 @@ class Adapter(object):
             return False
         return True
 
+    @property
+    def uuids(self):
+        """List of 128-bit UUIDs that represent available remote services."""
+        return self.adapter_props.Get(
+            constants.ADAPTER_INTERFACE, 'UUIDs')
+
     def get_managed_device_list(self):
         """Return a list of Devices manageable by this adapter"""
         device_objects_list = []
@@ -221,7 +227,8 @@ class Adapter(object):
             if remote_device is not None:
                 device_addr = remote_device.get("Address")
                 if device_addr is not None:
-                    device_objects_list.append(device.Device(self.address, device_addr))
+                    device_objects_list.append(
+                        device.Device(self.address, device_addr))
         return device_objects_list
 
     def nearby_discovery(self, timeout=10):

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -30,7 +30,7 @@ logger.setLevel(logging.WARNING)
 logger.addHandler(NullHandler())
 
 
-class Device:
+class Device(object):
     """Remote Bluetooth Device Class.
 
     This class instantiates an object that interacts with a remote

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -240,6 +240,13 @@ class Device:
             constants.DEVICE_INTERFACE,
             'ServicesResolved')
 
+    def pair(self):
+        """
+        Pair the device
+        :return: Boolean indicating if pairing was successful
+        """
+        self.remote_device_methods.Pair()
+
     def connect(self, profile=None):
         """
         Initiate a connection to the remote device.


### PR DESCRIPTION
**Add uuid attribute to Adapter** 
    According to:
    https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt
    Adapter1 interface has for attribute a list of UUIDs corresponding to the
    physical device.
    We here made this list available to the Adapter python class.

**Added object inheritance** 
    As we are running python 2.7 we need
    to inherit from object to take advantage
    of @property decorators.

**Add method to Pair device** 
    According to
    https://git.kernel.org/pubs/scm/bluetooth/bluez.git/tree/doc/device-api.txt
    Device dbus object provides a method to pair.

**Add a method to get Devices assigned to an Adapter** 
    This is necessary when we want to filter which device we will work with.
    Another way would have been to use the device filter of an adapter
    for more details:
    https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt

**Add asynchronous scan** 
    Now Adapter can perform safe asynchronous scans.