### PR TITLE
Add uuid attribute to Adapter

### DIFF
--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -211,6 +211,12 @@ class Adapter:
             return False
         return True
 
+    @property
+    def uuids(self):
+        """List of 128-bit UUIDs that represent available remote services."""
+        return self.adapter_props.Get(
+            constants.ADAPTER_INTERFACE, 'UUIDs')
+
     def nearby_discovery(self, timeout=10):
         """Start discovery of nearby Bluetooth devices."""
         self._nearby_timeout = timeout


### PR DESCRIPTION
According to:
https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt
Adapter1 interface has for attribute a list of UUIDs corresponding to the
physical device.

We here made this list available to the Adapter python class.