### PR TITLE
Add method to Pair device and cancel pairing

### DIFF
--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -240,6 +240,19 @@ class Device:
             constants.DEVICE_INTERFACE,
             'ServicesResolved')
 
+    def pair(self):
+        """
+        Pair the device
+        """
+        self.remote_device_methods.Pair()
+
+    def cancel_pairing(self):
+        """
+        This method can be used to cancel a pairing
+        operation initiated by the pair method
+        """
+        self.remote_device_methods.CancelPairing()
+
     def connect(self, profile=None):
         """
         Initiate a connection to the remote device.


### PR DESCRIPTION
According to
https://git.kernel.org/pubs/scm/bluetooth/bluez.git/tree/doc/device-api.txt
Device dbus object provides a method to pair and cancel pairing.