### PR TITLE
Changed example

### DIFF
--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -58,7 +58,7 @@ class Adapter:
 
     >>> from bluezero import adapter
     >>> dongle = adapter.Adapter()
-    >>> dongle.powered = True
+    >>> dongle.powered = dbus.Boolean(True)
 
     """
 


### PR DESCRIPTION
Python True is not understood by Dbus api as 1, consequently dbus.Boolean should
be used.