### PR TITLE
microbit: don't load gatt twice

### DIFF
--- a/bluezero/microbit.py
+++ b/bluezero/microbit.py
@@ -144,9 +144,6 @@ class Microbit:
         Connect to the specified micro:bit for this instance
         """
         self.ubit.connect()
-        while not self.ubit.services_resolved:
-            sleep(0.5)
-        self.ubit.load_gatt()
 
     def disconnect(self):
         """


### PR DESCRIPTION
If I am not mistaken this code is not needed, as the same code is executed anyway while calling *central.Central.connect()*