### PR TITLE
Change behaviour for subscribe_button_x and subscribe_pins

### DIFF
--- a/examples/async_example.py
+++ b/examples/async_example.py
@@ -4,10 +4,8 @@ cmdr = microbit.BitCommander(adapter_addr='B8:27:EB:22:57:E0',
                              device_addr='E3:AC:D2:F8:EB:B9')
 
 
-def button_callback(*args, **kwargs):
-    print('Hello, World')
-    print('args = ', args)
-    print('kwargs = ', kwargs)
+def button_callback(status):
+    print('Button A status: ', status)
 
 
 def pin_callback(pin, value):


### PR DESCRIPTION
Tested with bluez 5.50

`subscribe_button_x` and `subscribe_pins` already invoke a response which does not contain the key `Value` (but a key `Notifying`). This results in an error in `subscribe_pins` (which expects a key `Value`) and gives an unexpected behaviour for the callback of `subscribe_button_x` because it is already invoked although not button was pressed.

This PR
- checks if a key `Value` is present, only then is the user callback invoked
- make changes so that user callback for `subscribe_button_x` receives the button status (0, 1, 2)