### PR TITLE
dbus_tools: _get_dbus_path2 improvement

### DIFF
--- a/bluezero/dbus_tools.py
+++ b/bluezero/dbus_tools.py
@@ -125,7 +125,7 @@ def _get_dbus_path2(objects, parent_path, iface_in, prop, value):
         if props[prop].lower() == value.lower() and \
                 path.startswith(parent_path):
             return path
-
+    raise ValueError('Bad combination of inputs: found nothing')
 
 def get_dbus_path(adapter=None,
                   device=None,

--- a/tests/test_dbus_tools.py
+++ b/tests/test_dbus_tools.py
@@ -71,10 +71,11 @@ class TestDbusModuleCalls(unittest.TestCase):
         self.assertEqual(constants.GATT_DESC_IFACE, my_iface)
 
     def test_profile_path(self):
-        my_iface = self.module_under_test.get_profile_path(adapter='00:00:00:00:5A:AD',
-                                                           device='F7:17:E4:09:C0:C6',
-                                                           profile='e95df2d8-251d-470a-a062-fa1922dfa9a8')
-        self.assertEqual(None, my_iface)
+        self.assertRaises(ValueError,
+                          self.module_under_test.get_profile_path,
+                          adapter='00:00:00:00:5A:AD',
+                          device='F7:17:E4:09:C0:C6',
+                          profile='e95df2d8-251d-470a-a062-fa1922dfa9a8')
 
     def test_bluez_version(self):
         bluez_ver = self.module_under_test.bluez_version()


### PR DESCRIPTION
The error raising behavior of get_dbus path is not consistent, in fact:
In the case get_dbus_path is called with a correct adapter and
an erroneous device the function will silently return None.
In the case get_dbus_path is called with a correct device and an
erroneous adapter the function will raise a Value error because
_get_dbus_path is called with None on the second call.

Here we make the behavior uniform to allow better error management
where this function is used.
This change allows to raise an error instead of silently returning None in the
case only the last call to _get_dbus_path2 return None.

This what we get post-patch:
````
adapter_adress = " 38:BA:F8:ED:81:C1 " # This is correct and the adapter is plugged in
device_address = "This address does not exist"
device_object = device.Device(adapter_adress, device_address)

  File "/home/tkostas/avr/python-bluezero/bluezero/device.py", line 53, in __init__
    device_path = dbus_tools.get_dbus_path(adapter_addr, device_addr)
  File "/home/tkostas/avr/python-bluezero/bluezero/dbus_tools.py", line 157, in get_dbus_path
    adapter)
  File "/home/tkostas/avr/python-bluezero/bluezero/dbus_tools.py", line 128, in _get_dbus_path2
    raise ValueError('Bad combination of inputs: found nothing')
ValueError: Bad combination of inputs: found nothing
Process finished with exit code 1
````

````
adapter_adress = " This adapter does not exist" # This is correct and the adapter is plugged in
device_address = "38:BA:F8:ED:81:42" # This device address exist and has a dbus path
device_object = device.Device(adapter_adress, device_address)

 File "/home/tkostas/avr/python-bluezero/bluezero/device.py", line 53, in __init__
    device_path = dbus_tools.get_dbus_path(adapter_addr, device_addr)
  File "/home/tkostas/avr/python-bluezero/bluezero/dbus_tools.py", line 157, in get_dbus_path
    adapter)
  File "/home/tkostas/avr/python-bluezero/bluezero/dbus_tools.py", line 128, in _get_dbus_path2
    raise ValueError('Bad combination of inputs: found nothing')
ValueError: Bad combination of inputs: found nothing

Process finished with exit code 1
````

Pre-patch

````
adapter_adress = " This adapter does not exist" # This is correct and the adapter is plugged in
device_address = "38:BA:F8:ED:81:42" # This device address exist and has a dbus path
device_object = device.Device(device_address, device_address)

    device_object = device.Device(device_address, device_address)
  File "/home/tkostas/avr/python-bluezero/bluezero/device.py", line 53, in __init__
    device_path = dbus_tools.get_dbus_path(adapter_addr, device_addr)
  File "/home/tkostas/avr/python-bluezero/bluezero/dbus_tools.py", line 164, in get_dbus_path
    device)
  File "/home/tkostas/avr/python-bluezero/bluezero/dbus_tools.py", line 120, in _get_dbus_path2
    raise ValueError('Bad combination of inputs: found nothing')
ValueError: Bad combination of inputs: found nothing
````

````
adapter_adress = "38:BA:F8:ED:81:C1" # This is correct and the adapter is plugged in
device_address = "This address does not exist"
device_object = device.Device(adapter_adress, device_address)

    device_object = device.Device(adapter_adress, device_address)
  File "/home/tkostas/avr/python-bluezero/bluezero/device.py", line 58, in __init__
    self.remote_device_path)
  File "/usr/lib/python2.7/dist-packages/dbus/bus.py", line 241, in get_object
    follow_name_owner_changes=follow_name_owner_changes)
  File "/usr/lib/python2.7/dist-packages/dbus/proxies.py", line 244, in __init__
    _dbus_bindings.validate_object_path(object_path)
TypeError: validate_object_path() argument 1 must be string, not None
````