### PR TITLE
dbus_tools: _get_dbus_path2 improvement

### DIFF
--- a/bluezero/dbus_tools.py
+++ b/bluezero/dbus_tools.py
@@ -117,7 +117,7 @@ def _get_dbus_path2(objects, parent_path, iface_in, prop, value):
     :return: Path of object searched for
     """
     if parent_path is None:
-        raise ValueError('Bad combination of inputs: found nothing')
+        return None
     for path, iface in objects.items():
         props = iface.get(iface_in)
         if props is None:
@@ -125,6 +125,7 @@ def _get_dbus_path2(objects, parent_path, iface_in, prop, value):
         if props[prop].lower() == value.lower() and \
                 path.startswith(parent_path):
             return path
+    return None
 
 
 def get_dbus_path(adapter=None,

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -51,6 +51,9 @@ class Device(object):
         self.mainloop = GObject.MainLoop()
 
         device_path = dbus_tools.get_dbus_path(adapter_addr, device_addr)
+        if not device_path:
+            raise ValueError("Cannot find a device: " + device_addr +
+                             " using adapter: " + adapter_addr)
 
         self.remote_device_path = device_path
         self.remote_device_obj = self.bus.get_object(

--- a/tests/test_dbus_tools.py
+++ b/tests/test_dbus_tools.py
@@ -56,11 +56,11 @@ class TestDbusModuleCalls(unittest.TestCase):
         self.assertEqual(dbus_full_path, expected_result)
 
     def test_bad_path(self):
-        self.assertRaises(ValueError,
-                          self.module_under_test.get_dbus_path,
-                          adapter='00:00:00:00:5A:C6',
-                          device='F7:17:E4:09:C0:XX',
-                          service='e95df2d8-251d-470a-a062-fa1922dfa9a8')
+        path_found = self.module_under_test.get_dbus_path(adapter='00:00:00:00:5A:C6',
+                                                          device='F7:17:E4:09:C0:XX',
+                                                          service='e95df2d8-251d-470a-a062-fa1922dfa9a8')
+        expected_path = None
+        self.assertEqual(path_found, expected_path)
 
     def test_get_iface_from_path(self):
         my_iface = self.module_under_test.get_iface(adapter='00:00:00:00:5A:AD',

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -45,6 +45,12 @@ class TestBluezeroDevice(unittest.TestCase):
     def tearDown(self):
         self.module_patcher.stop()
 
+    def test_bad_device(self):
+        self.assertRaises(ValueError,
+                          self.module_under_test.Device,
+                          self.adapter_addr,
+                          "bad_device_address")
+
     def test_device_name(self):
         ble_dev = self.module_under_test.Device(self.adapter_addr, self.device_addr)
         self.assertEqual(ble_dev.name, self.dev_name)


### PR DESCRIPTION
The error raising behavior of get_dbus path is not consistent, in fact:
In the case get_dbus_path is called with a correct adapter and
an erroneous device the function will silently return None.
In the case get_dbus_path is called with a correct device and an
erroneous adapter the function will raise a Value error because
_get_dbus_path is called with None on the second call.

Here we make the behavior uniform to allow better error management
where this function is used.
This change allows to uniformly return None when the dbus_path requested does not exist.


NEW APPROACH based on discussions in #246 