### PR TITLE
Fix disconnection on some dongles!

### DIFF
--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -284,7 +284,10 @@ class Adapter(object):
                     adapter_addr=self.address,
                     device_addr=device_info[dev_iface]['Address'])
                 self.on_device_found(new_dev)
-                if device_info[dev_iface]['Connected'] and self.on_connect:
+            if device_info[dev_iface]['Connected'] and self.on_connect:
+                    new_dev = device.Device(
+                        adapter_addr=self.address,
+                        device_addr=device_info[dev_iface]['Address'])
                     self.on_connect(new_dev)
 
 

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -262,8 +262,12 @@ class Adapter(object):
         """
         macaddr = dbus_tools.get_mac_addr_from_dbus_path(path)
         if 'Connected' in changed:
-
-            if not changed['Connected'] and self.on_disconnect:
+            if changed['Connected'] and self.on_connect:
+                new_dev = device.Device(
+                    adapter_addr=self.address,
+                    device_addr=macaddr)
+                self.on_connect(new_dev)
+            elif not changed['Connected'] and self.on_disconnect:
                 if tools.get_fn_parameters(self.on_disconnect) == 0:
                     logger.warn("using deprecated version of disconnect " +
                                 "callback, move to on_disconnect(dev) " +

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -289,10 +289,10 @@ class Adapter(object):
                     device_addr=device_info[dev_iface]['Address'])
                 self.on_device_found(new_dev)
             if device_info[dev_iface]['Connected'] and self.on_connect:
-                    new_dev = device.Device(
-                        adapter_addr=self.address,
-                        device_addr=device_info[dev_iface]['Address'])
-                    self.on_connect(new_dev)
+                new_dev = device.Device(
+                    adapter_addr=self.address,
+                    device_addr=device_info[dev_iface]['Address'])
+                self.on_connect(new_dev)
 
     def _interfaces_removed(self, path, device_info):
         """

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -262,19 +262,15 @@ class Adapter(object):
         """
         macaddr = dbus_tools.get_mac_addr_from_dbus_path(path)
         if 'Connected' in changed:
-            new_dev = device.Device(
-                adapter_addr=self.address,
-                device_addr=macaddr)
-            if changed['Connected'] and self.on_connect:
-                self.on_connect(new_dev)
-            elif not changed['Connected'] and self.on_disconnect:
+
+            if not changed['Connected'] and self.on_disconnect:
                 if tools.get_fn_parameters(self.on_disconnect) == 0:
                     logger.warn("using deprecated version of disconnect " +
                                 "callback, move to on_disconnect(dev) " +
                                 "with device parameter")
                     self.on_disconnect()
                 elif tools.get_fn_parameters(self.on_disconnect) == 1:
-                    self.on_disconnect(new_dev)
+                    self.on_disconnect(macaddr)
 
     def _interfaces_added(self, path, device_info):
         """
@@ -288,6 +284,9 @@ class Adapter(object):
                     adapter_addr=self.address,
                     device_addr=device_info[dev_iface]['Address'])
                 self.on_device_found(new_dev)
+            if device_info[dev_iface]['Connected'] and self.on_connect:
+                self.on_connect(new_dev)
+
 
     def _interfaces_removed(self, path, device_info):
         """

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -294,7 +294,6 @@ class Adapter(object):
                         device_addr=device_info[dev_iface]['Address'])
                     self.on_connect(new_dev)
 
-
     def _interfaces_removed(self, path, device_info):
         """
         Handle DBus InterfacesRemoved signal and

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -284,8 +284,8 @@ class Adapter(object):
                     adapter_addr=self.address,
                     device_addr=device_info[dev_iface]['Address'])
                 self.on_device_found(new_dev)
-            if device_info[dev_iface]['Connected'] and self.on_connect:
-                self.on_connect(new_dev)
+                if device_info[dev_iface]['Connected'] and self.on_connect:
+                    self.on_connect(new_dev)
 
 
     def _interfaces_removed(self, path, device_info):


### PR DESCRIPTION
I did some time ago  a PR adding connection Cb. I tested with some adapters but I noticed dbus worked in a different way...Connected property was not notified.
So I moved connection callback also in "add interface" method . I don't know what is related to this behavior  ..maybe different dongles and timing ?

another thing is the disconnection callback cannot have device as parameter 'casue I noticed can happen that dev is not ready anymore: so I just notified the user with a mac address string. If I think it sounds good because in connection cb you have a dev reference to work with but in the disconnection the device is gone.


Marco
