### PR TITLE
fix bug: observer.py asyncio socket type error

### DIFF
--- a/bluezero/observer.py
+++ b/bluezero/observer.py
@@ -41,8 +41,9 @@ def scan_eddystone(on_data=None):
     mysocket = aioblescan.create_bt_socket(mydev)
 
     # create a connection with the raw socket
-    fac = event_loop.create_connection(aioblescan.BLEScanRequester,
-                                       sock=mysocket)
+    fac=event_loop._create_connection_transport(mysocket,
+                                                aioblescan.BLEScanRequester,
+                                                None, None)
     # Start it
     conn, btctrl = event_loop.run_until_complete(fac)
     # Attach your processing


### PR DESCRIPTION
I got an error when I tried to run `example/eddystone-scanner.py`. The error log was like that:

```Shell
sudo python3 examples/eddystone-scanner.py
Traceback (most recent call last):
  File "examples/eddystone-scanner.py", line 32, in <module>
    observer.scan_eddystone(on_data=print_eddystone_values)
  File "/home/USER/python-bluezero/bluezero/observer.py", line 47, in scan_eddystone
    conn, btctrl = event_loop.run_until_complete(fac)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/usr/lib/python3.8/asyncio/base_events.py", line 1047, in create_connection
    raise ValueError(
ValueError: A Stream Socket was expected, got <socket.socket fd=6, family=AddressFamily.AF_BLUETOOTH, type=SocketKind.SOCK_RAW, proto=1>
```

I thought there was something wrong with **aioblescan** module. Therefore, I checked the **aioblescan** source codes at [this repo](https://github.com/frawau/aioblescan) and found that there is a piece of codes at `aioblescan/__main__.py` that is very similar to the error codes at `bluezero/observer.py`. The related **aioblescan** codes are: ([link to codes](https://github.com/frawau/aioblescan/blob/master/aioblescan/__main__.py))

```Python
event_loop = asyncio.get_event_loop()

#First create and configure a raw socket
mysocket = aiobs.create_bt_socket(opts.device)

#create a connection with the raw socket
#This used to work but now requires a STREAM socket.
#fac=event_loop.create_connection(aiobs.BLEScanRequester,sock=mysocket)
#Thanks to martensjacobs for this fix
fac=event_loop._create_connection_transport(mysocket,aiobs.BLEScanRequester,None,None)
#Start it
conn,btctrl = event_loop.run_until_complete(fac)
#Attach your processing
btctrl.process=my_process
```

I think the error reason is clearly explained in the commented codes. So, I modified the codes at `bluezero/observer.py` just like they did in **aioblescan** and tested it on an ubuntu 20.04 (BlueZ version 5.53) machine. Everything was fine this time.