### PR TITLE
provide for unnamed devices

### DIFF
--- a/bluezero/dbus_tools.py
+++ b/bluezero/dbus_tools.py
@@ -318,6 +318,12 @@ def get_props(adapter=None,
 
     return get_dbus_iface(dbus.PROPERTIES_IFACE, get_dbus_obj(path_obj))
 
+def get_prop_or_none(props, iface, name):
+    try:
+        return props.Get(iface, name)
+    except dbus.exceptions.DBusException:
+        return None
+
 
 def str_to_dbusarray(word):
     return dbus.Array([dbus.Byte(ord(letter)) for letter in word], 'y')

--- a/bluezero/dbus_tools.py
+++ b/bluezero/dbus_tools.py
@@ -318,12 +318,14 @@ def get_props(adapter=None,
 
     return get_dbus_iface(dbus.PROPERTIES_IFACE, get_dbus_obj(path_obj))
 
-def get_prop_or_none(props, iface, name):
+def get(dbus_prop_obj, dbus_iface, prop_name, default=None):
     try:
-        return props.Get(iface, name)
-    except dbus.exceptions.DBusException:
-        return None
-
+        return dbus_prop_obj.Get(dbus_iface, prop_name)
+    except dbus.exceptions.DBusException as dbus_exception:
+        if dbus_exception.get_dbus_name() == 'org.freedesktop.DBus.Error.InvalidArgs':
+            return default
+        else:
+            raise dbus_exception
 
 def str_to_dbusarray(word):
     return dbus.Array([dbus.Byte(ord(letter)) for letter in word], 'y')

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -74,11 +74,10 @@ class Device(object):
     @property
     def name(self):
         """Return the remote device name."""
-        try:
-            return self.remote_device_props.Get(
-                constants.DEVICE_INTERFACE, 'Name')
-        except dbus.exceptions.DBusException:
-            return None
+        return dbus_tools.get_prop_or_none(
+            self.remote_device_props,
+            constants.DEVICE_INTERFACE,
+            'Name')
 
     @property
     def icon(self):

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -74,10 +74,9 @@ class Device(object):
     @property
     def name(self):
         """Return the remote device name."""
-        return dbus_tools.get_prop_or_none(
-            self.remote_device_props,
-            constants.DEVICE_INTERFACE,
-            'Name')
+        return dbus_tools.get(
+            self.remote_device_props, constants.DEVICE_INTERFACE,
+            'Name', None)
 
     @property
     def icon(self):

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -74,8 +74,11 @@ class Device(object):
     @property
     def name(self):
         """Return the remote device name."""
-        return self.remote_device_props.Get(
-            constants.DEVICE_INTERFACE, 'Name')
+        try:
+            return self.remote_device_props.Get(
+                constants.DEVICE_INTERFACE, 'Name')
+        except dbus.exceptions.DBusException:
+            return None
 
     @property
     def icon(self):


### PR DESCRIPTION
After #285, I found a device in my environment that crashed bluezero because it had no name.   This provides for missing names.