### PR TITLE
Timing out Connecting

### DIFF
--- a/bluezero/central.py
+++ b/bluezero/central.py
@@ -68,17 +68,18 @@ class Central:
         """Indicate whether the remote device is currently connected."""
         return self.rmt_device.connected
 
-    def connect(self, profile=None):
+    def connect(self, profile=None, timeout=1):
         """
         Initiate a connection to the remote device and load
         GATT database once resolved
 
         :param profile: (optional) profile to use for the connection.
+        :param timeout: (optional) seconds to wait for connection.
         """
         if profile is None:
-            self.rmt_device.connect()
+            self.rmt_device.connect(timeout=timeout)
         else:
-            self.rmt_device.connect(profile)
+            self.rmt_device.connect(profile, timeout=timeout)
         while not self.rmt_device.services_resolved:
             sleep(0.5)
         self.load_gatt()

--- a/bluezero/central.py
+++ b/bluezero/central.py
@@ -68,7 +68,7 @@ class Central:
         """Indicate whether the remote device is currently connected."""
         return self.rmt_device.connected
 
-    def connect(self, profile=None, timeout=1):
+    def connect(self, profile=None, timeout=35):
         """
         Initiate a connection to the remote device and load
         GATT database once resolved

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -271,16 +271,25 @@ class Device(object):
         """
         self.remote_device_methods.CancelPairing()
 
-    def connect(self, profile=None):
+    def connect(self, profile=None, timeout=1):
         """
         Initiate a connection to the remote device.
 
         :param profile: (optional) profile to use for the connection.
+        :param timeout: (optional) the number of seconds to spend trying to connect.
         """
-        if profile is None:
-            self.remote_device_methods.Connect()
-        else:
-            self.remote_device_methods.ConnectProfile(profile)
+        try:
+            if profile is None:
+                self.bus.call_blocking(constants.BLUEZ_SERVICE_NAME, self.remote_device_path, constants.DEVICE_INTERFACE, 'Connect', '', [], timeout=timeout)
+            else:
+                ## need a device to test next line with.  for now, timeout ignored for profile connections.
+                #self.bus.call_blocking(constants.BLUEZ_SERVICE_NAME, self.remote_device_path, constants.DEVICE_INTERFACE, 'ConnectProfile', 's', [profile], timeout=timeout)
+                self.remote_device_methods.ConnectProfile(profile)
+        except dbus.exceptions.DBusException as dbus_exception:
+            if dbus_exception.get_dbus_name() == 'org.freedesktop.DBus.Error.NoReply':
+                # move driver back from connecting state to disconnected state
+                self.disconnect()
+            raise dbus_exception
 
     def disconnect(self):
         """Disconnect from the remote device."""

--- a/bluezero/device.py
+++ b/bluezero/device.py
@@ -271,7 +271,7 @@ class Device(object):
         """
         self.remote_device_methods.CancelPairing()
 
-    def connect(self, profile=None, timeout=1):
+    def connect(self, profile=None, timeout=35):
         """
         Initiate a connection to the remote device.
 


### PR DESCRIPTION
This adds a timeout parameter to Device.connect and Central.connect .  Otherwise you wait 35 seconds until dbus gives up.

I wasn't sure how to handle the case of timing out.  For now it reraises the error even if it is from a timeout.

Additionally, I didn't add this to ConnectProfile because I don't have a profile to connect to, to test it, right now.