### PR TITLE
Expose on_connect and on_disconnect callbacks for the Peripheral

### DIFF
--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -275,12 +275,12 @@ class Adapter:
         macaddr = dbus_tools.get_device_address_from_dbus_path(path)
         adapter_addr = dbus_tools.get_adapter_address_from_dbus_path(path)
         if 'Connected' in changed:
+            new_dev = device.Device(
+                adapter_addr=self.address,
+                device_addr=macaddr)
             if changed['Connected'] and self.address == adapter_addr:
-                new_dev = device.Device(
-                    adapter_addr=self.address,
-                    device_addr=macaddr)
-            if changed['Connected'] and self.on_connect:
-                self.on_connect(new_dev)
+                if self.on_connect:
+                    self.on_connect(new_dev)
             elif not changed['Connected'] and self.on_disconnect:
                 if tools.get_fn_parameters(self.on_disconnect) == 0:
                     logger.warning("using deprecated version of disconnect "

--- a/bluezero/adapter.py
+++ b/bluezero/adapter.py
@@ -272,15 +272,21 @@ class Adapter:
         Handle DBus PropertiesChanged signal and
         call appropriate user callback
         """
-        macaddr = dbus_tools.get_device_address_from_dbus_path(path)
+        device_address = dbus_tools.get_device_address_from_dbus_path(path)
         adapter_addr = dbus_tools.get_adapter_address_from_dbus_path(path)
         if 'Connected' in changed:
-            new_dev = device.Device(
-                adapter_addr=self.address,
-                device_addr=macaddr)
-            if changed['Connected'] and self.address == adapter_addr:
-                if self.on_connect:
+            if all((changed['Connected'],
+                    self.address == adapter_addr,
+                    self.on_connect)):
+                if tools.get_fn_parameters(self.on_connect) == 0:
+                    self.on_connect()
+                elif tools.get_fn_parameters(self.on_connect) == 1:
+                    new_dev = device.Device(
+                        adapter_addr=self.address,
+                        device_addr=device_address)
                     self.on_connect(new_dev)
+                elif tools.get_fn_parameters(self.on_connect) == 2:
+                    self.on_connect(adapter_addr, device_address)
             elif not changed['Connected'] and self.on_disconnect:
                 if tools.get_fn_parameters(self.on_disconnect) == 0:
                     logger.warning("using deprecated version of disconnect "
@@ -288,7 +294,12 @@ class Adapter:
                                    "with device parameter")
                     self.on_disconnect()
                 elif tools.get_fn_parameters(self.on_disconnect) == 1:
+                    new_dev = device.Device(
+                        adapter_addr=self.address,
+                        device_addr=device_address)
                     self.on_disconnect(new_dev)
+                elif tools.get_fn_parameters(self.on_disconnect) == 2:
+                    self.on_disconnect(self.address, device_address)
 
     def _interfaces_added(self, path, device_info):
         """
@@ -297,16 +308,21 @@ class Adapter:
         """
         dev_iface = constants.DEVICE_INTERFACE
         if constants.DEVICE_INTERFACE in device_info:
-            dev_addr = device_info[dev_iface]['Address']
-            if self.on_device_found is not None and dev_addr:
+            dev_addr = device_info[dev_iface].get('Address')
+            dev_connected = device_info[dev_iface].get('Connected')
+            if self.on_device_found and dev_addr:
                 new_dev = device.Device(
                     adapter_addr=self.address,
                     device_addr=dev_addr)
                 self.on_device_found(new_dev)
+            if all((self.on_connect, dev_connected, dev_addr)):
+                new_dev = device.Device(
+                    adapter_addr=self.address,
+                    device_addr=dev_addr)
+                self.on_connect(new_dev)
 
     def _interfaces_removed(self, path, device_info):
         """
         Handle DBus InterfacesRemoved signal and
         call appropriate user callback
         """
-        pass

--- a/bluezero/dbus_tools.py
+++ b/bluezero/dbus_tools.py
@@ -140,7 +140,7 @@ def _get_dbus_path2(objects, parent_path, iface_in, prop, value):
         props = iface.get(iface_in)
         if props is None:
             continue
-        if props[prop].lower() == value.lower() and \
+        if (props[prop].lower() == value.lower() or path.lower().endswith("dev_" + value.lower().replace(":", "_"))) and \
                 path.startswith(parent_path):
             return path
     return None

--- a/bluezero/dbus_tools.py
+++ b/bluezero/dbus_tools.py
@@ -115,7 +115,6 @@ def get_device_address_from_dbus_path(path):
             return path_elem.replace("dev_", '').replace("_", ":")
     return ''
 
-
 def get_adapter_address_from_dbus_path(path):
     """Return the address of the adapter from the a DBus path"""
     result = re.match(r'/org/bluez/hci\d+', path)
@@ -140,8 +139,10 @@ def _get_dbus_path2(objects, parent_path, iface_in, prop, value):
         props = iface.get(iface_in)
         if props is None:
             continue
-        if (props[prop].lower() == value.lower() or path.lower().endswith("dev_" + value.lower().replace(":", "_"))) and \
-                path.startswith(parent_path):
+        dev_name = "dev_" + value.lower().replace(":", "_")
+        if (props[prop].lower() == value.lower() or
+            path.lower().endswith(dev_name)) \
+                and path.startswith(parent_path):
             return path
     return None
 

--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -151,7 +151,9 @@ class Peripheral:
     def on_connect(self):
         """
         Callback for when a device connects to the peripheral.
-        Callback should take one parameter which is a Bluezero Device object
+        Callback can accept 0, 1, or 2 positional arguments
+        1: a device.Device instance of the connected target
+        2: the local adapter address followed by the remote address
         """
         return self.dongle.on_connect
 
@@ -163,8 +165,9 @@ class Peripheral:
     def on_disconnect(self):
         """
         Callback for when a device disconnects from the peripheral.
-        Callback takes either one parameter: a Bluezero Device object
-        or no parameters
+        Callback can accept 0, 1, or 2 positional arguments
+        1: a device.Device instance of the disconnected target
+        2: the local adapter address followed by the remote address
         """
         return self.dongle.on_disconnect
 

--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -146,3 +146,28 @@ class Peripheral:
         except KeyboardInterrupt:
             self.mainloop.quit()
             self.ad_manager.unregister_advertisement(self.advert)
+
+    @property
+    def on_connect(self):
+        """
+        Callback for when a device connects to the peripheral.
+        Callback should take one parameter which is a Bluezero Device object
+        """
+        return self.dongle.on_connect
+
+    @on_connect.setter
+    def on_connect(self, callback):
+        self.dongle.on_connect = callback
+
+    @property
+    def on_disconnect(self):
+        """
+        Callback for when a device disconnects from the peripheral.
+        Callback takes either one parameter: a Bluezero Device object
+        or no parameters
+        """
+        return self.dongle.on_disconnect
+
+    @on_disconnect.setter
+    def on_disconnect(self, callback):
+        self.dongle.on_disconnect = callback

--- a/bluezero/tools.py
+++ b/bluezero/tools.py
@@ -151,7 +151,10 @@ def url_to_advert(url, frame_type, tx_power):
 
 def get_fn_parameters(fn):
     """ return the number of input parameters of the fn , None on error"""
-    return len(inspect.getfullargspec(fn).args)
+    param_len = len(inspect.getfullargspec(fn).args)
+    if inspect.ismethod(fn):
+        param_len -= 1
+    return param_len
 
 
 def create_module_logger(module_name):

--- a/examples/ble_uart.py
+++ b/examples/ble_uart.py
@@ -58,8 +58,8 @@ def main(adapter_address):
                                 read_callback=None,
                                 write_callback=None)
 
-    ble_uart.dongle.on_connect = on_connect
-    ble_uart.dongle.on_disconnect = on_disconnect
+    ble_uart.on_connect = on_connect
+    ble_uart.on_disconnect = on_disconnect
 
     ble_uart.publish()
 

--- a/examples/ble_uart.py
+++ b/examples/ble_uart.py
@@ -14,7 +14,7 @@ tx_obj = None
 
 
 def on_connect(ble_device: device.Device):
-    print("Connected fun to " + str(ble_device.address))
+    print("Connected to " + str(ble_device.address))
 
 
 def on_disconnect(ble_device: device.Device):
@@ -43,7 +43,7 @@ def uart_write(value, options):
 
 
 def main(adapter_address):
-    ble_uart = peripheral.Peripheral(adapter_address, local_name='Waydoo Flyer Foil')
+    ble_uart = peripheral.Peripheral(adapter_address, local_name='BLE UART')
     ble_uart.add_service(srv_id=1, uuid=UART_SERVICE, primary=True)
     ble_uart.add_characteristic(srv_id=1, chr_id=1, uuid=RX_CHARACTERISTIC,
                                 value=[], notifying=False,
@@ -52,7 +52,7 @@ def main(adapter_address):
                                 read_callback=None,
                                 notify_callback=None)
     ble_uart.add_characteristic(srv_id=1, chr_id=2, uuid=TX_CHARACTERISTIC,
-                                value=[], notifying=True,
+                                value=[], notifying=False,
                                 flags=['notify'],
                                 notify_callback=uart_notify,
                                 read_callback=None,

--- a/examples/ble_uart.py
+++ b/examples/ble_uart.py
@@ -1,4 +1,4 @@
-from gi.repository import GLib
+# from gi.repository import GLib
 
 # Bluezero modules
 from bluezero import adapter

--- a/examples/ble_uart.py
+++ b/examples/ble_uart.py
@@ -1,4 +1,4 @@
-# from gi.repository import GLib
+from gi.repository import GLib
 
 # Bluezero modules
 from bluezero import adapter
@@ -11,7 +11,7 @@ RX_CHARACTERISTIC = '6E400002-B5A3-F393-E0A9-E50E24DCCA9E'
 TX_CHARACTERISTIC = '6E400003-B5A3-F393-E0A9-E50E24DCCA9E'
 
 
-class MyDevice:
+class UARTDevice:
     tx_obj = None
 
     @classmethod
@@ -49,18 +49,18 @@ def main(adapter_address):
     ble_uart.add_characteristic(srv_id=1, chr_id=1, uuid=RX_CHARACTERISTIC,
                                 value=[], notifying=False,
                                 flags=['write', 'write-without-response'],
-                                write_callback=MyDevice.uart_write,
+                                write_callback=UARTDevice.uart_write,
                                 read_callback=None,
                                 notify_callback=None)
     ble_uart.add_characteristic(srv_id=1, chr_id=2, uuid=TX_CHARACTERISTIC,
                                 value=[], notifying=False,
                                 flags=['notify'],
-                                notify_callback=MyDevice.uart_notify,
+                                notify_callback=UARTDevice.uart_notify,
                                 read_callback=None,
                                 write_callback=None)
 
-    ble_uart.on_connect = MyDevice.on_connect
-    ble_uart.on_disconnect = MyDevice.on_disconnect
+    ble_uart.on_connect = UARTDevice.on_connect
+    ble_uart.on_disconnect = UARTDevice.on_disconnect
 
     ble_uart.publish()
 

--- a/examples/ble_uart.py
+++ b/examples/ble_uart.py
@@ -3,6 +3,7 @@ from gi.repository import GLib
 # Bluezero modules
 from bluezero import adapter
 from bluezero import peripheral
+from bluezero import device
 
 # constants
 UART_SERVICE = '6E400001-B5A3-F393-E0A9-E50E24DCCA9E'
@@ -10,6 +11,14 @@ RX_CHARACTERISTIC = '6E400002-B5A3-F393-E0A9-E50E24DCCA9E'
 TX_CHARACTERISTIC = '6E400003-B5A3-F393-E0A9-E50E24DCCA9E'
 
 tx_obj = None
+
+
+def on_connect(ble_device: device.Device):
+    print("Connected fun to " + str(ble_device.address))
+
+
+def on_disconnect(ble_device: device.Device):
+    print("Disconnected from " + str(ble_device.address))
 
 
 def uart_notify(notifying, characteristic):
@@ -22,6 +31,7 @@ def uart_notify(notifying, characteristic):
 
 def update_tx(value):
     if tx_obj:
+        print("Sending")
         tx_obj.set_value(value)
 
 
@@ -33,7 +43,7 @@ def uart_write(value, options):
 
 
 def main(adapter_address):
-    ble_uart = peripheral.Peripheral(adapter_address, local_name='BLE UART')
+    ble_uart = peripheral.Peripheral(adapter_address, local_name='Waydoo Flyer Foil')
     ble_uart.add_service(srv_id=1, uuid=UART_SERVICE, primary=True)
     ble_uart.add_characteristic(srv_id=1, chr_id=1, uuid=RX_CHARACTERISTIC,
                                 value=[], notifying=False,
@@ -42,11 +52,15 @@ def main(adapter_address):
                                 read_callback=None,
                                 notify_callback=None)
     ble_uart.add_characteristic(srv_id=1, chr_id=2, uuid=TX_CHARACTERISTIC,
-                                value=[], notifying=False,
+                                value=[], notifying=True,
                                 flags=['notify'],
                                 notify_callback=uart_notify,
                                 read_callback=None,
                                 write_callback=None)
+
+    ble_uart.dongle.on_connect = on_connect
+    ble_uart.dongle.on_disconnect = on_disconnect
+
     ble_uart.publish()
 
 


### PR DESCRIPTION
Based on #324 . I added properties into peripheral so that the connection callbacks are more accessible.

I also modified dbus_tools.py to account for an issue where the address used in the bluez path does not match the public address of the device. In this case nothing could happen and an exception was thrown.