### PR TITLE
Add constructor boolean flag in Characteristic class to return raw db…

### DIFF
--- a/bluezero/localGATT.py
+++ b/bluezero/localGATT.py
@@ -223,10 +223,12 @@ class Characteristic(dbus.service.Object):
                  flags,
                  read_callback=None,
                  write_callback=None,
-                 notify_callback=None):
+                 notify_callback=None,
+                 convert_dbus=True):
         self.read_callback = read_callback
         self.write_callback = write_callback
         self.notify_callback = notify_callback
+        self.convert_dbus = convert_dbus
 
         # Setup D-Bus object paths and register service
         service_path = (f'{constants.BLUEZERO_DBUS_OBJECT}/'
@@ -364,8 +366,10 @@ class Characteristic(dbus.service.Object):
         :return: value
         """
         if self.write_callback:
-            self.write_callback(dbus_tools.dbus_to_python(value),
-                                dbus_tools.dbus_to_python(options))
+            return_value = dbus_tools.dbus_to_python(value) if self.convert_dbus else value
+            return_options = dbus_tools.dbus_to_python(options) if self.convert_dbus else options
+            self.write_callback(return_value,
+                                return_options)
         self.Set(constants.GATT_CHRC_IFACE, 'Value', value)
 
     @dbus.service.method(constants.GATT_CHRC_IFACE,

--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -8,12 +8,12 @@ from bluezero import localGATT
 from bluezero import GATT
 from bluezero import tools
 
-
 logger = tools.create_module_logger(__name__)
 
 
 class Peripheral:
     """Create a Bluetooth BLE Peripheral"""
+
     def __init__(self, adapter_address, local_name=None, appearance=None):
         self.app = localGATT.Application()
         self.srv_mng = GATT.GattManager(adapter_address)
@@ -44,7 +44,7 @@ class Peripheral:
     def add_characteristic(self, srv_id, chr_id, uuid, value,
                            notifying, flags,
                            read_callback=None, write_callback=None,
-                           notify_callback=None):
+                           notify_callback=None, convert_dbus=True):
         """
         Add information for characteristic.
 
@@ -90,7 +90,7 @@ class Peripheral:
         """
         self.characteristics.append(localGATT.Characteristic(
             srv_id, chr_id, uuid, value, notifying, flags,
-            read_callback, write_callback, notify_callback
+            read_callback, write_callback, notify_callback, convert_dbus
         ))
 
     def add_descriptor(self, srv_id, chr_id, dsc_id, uuid, value, flags):


### PR DESCRIPTION
…us value instead of always implicitly converting it before calling write callback.

The implicit conversion using dbus_tools.dbus_to_python() can result in unwanted effects for those looking to use raw byte arrays in their code. For example, I am using the python struct library to parse raw byte arrays that are transmitted over a BLE connection. Often times this implicit conversion to python will convert the raw dbus value to the wrong data type and then struct is unable to parse. My simple addition allows users, to disable this conversion which is still enabled by default.