### PR TITLE
Allow service data advertisement for peripherals

### DIFF
--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -120,14 +120,17 @@ class Peripheral:
             srv_id, chr_id, dsc_id, uuid, value, flags
         ))
 
-    def _create_advertisement(self):
-        self.advert.service_UUIDs = self.primary_services
+    def _create_advertisement(self, service_data):
+        if service_data is None:
+            self.advert.service_UUIDs = self.primary_services
+        else:
+            self.advert.service_data = service_data
         if self.local_name:
             self.advert.local_name = self.local_name
         if self.appearance:
             self.advert.appearance = self.appearance
 
-    def publish(self):
+    def publish(self, service_data=None):
         """Create advertisement and make peripheral visible"""
         for service in self.services:
             self.app.add_managed_object(service)
@@ -135,10 +138,11 @@ class Peripheral:
             self.app.add_managed_object(chars)
         for desc in self.descriptors:
             self.app.add_managed_object(desc)
-        self._create_advertisement()
+        self._create_advertisement(service_data)
         if not self.dongle.powered:
             self.dongle.powered = True
         self.srv_mng.register_application(self.app, {})
+
         self.ad_manager.register_advertisement(self.advert, {})
 
         try:


### PR DESCRIPTION
The Android version of the NRF Wifi Provisioning app expects Service Data instead of typical advertised service UUIDs.

https://github.com/NordicSemiconductor/Android-nRF-Wi-Fi-Provisioner/blob/0094211ae252745dbd9b7805fb0e41ebd0f91cc6/app/src/main/java/no/nordicsemi/android/wifi/provisioning/scanner/ProvisioningData.kt#L56

Because their UUID is the full 128 bits, the advertisement fails to publish because it won't fit.  As far as I can tell, if you publish service data, LightBlue and NRFConnect all still see the service, so having service data should supercede the service advertisements.

I believe this is the most straightforward and user friendly way to do this.  I had also considered a "bluez_peripheral" like function call, but it doesn't seem needed right now.

`advert = Advertisement(name, [], 0, 0, serviceData={WIFI_COMMISSION_SERVICE_UUID:bytes([0x02, 0x00, 0x00, 0x00])})
    await advert.register(bus, adapter)`