### PR TITLE
Added ability to set advertising interval

### DIFF
--- a/bluezero/advertisement.py
+++ b/bluezero/advertisement.py
@@ -81,7 +81,9 @@ class Advertisement(dbus.service.Object):
                 'ServiceData': None,
                 'Includes': set(),
                 'Appearance': None,
-                'LocalName': None
+                'LocalName': None,
+                'MinInterval': None,
+                'MaxInterval': None,
             }
         }
 
@@ -182,6 +184,24 @@ class Advertisement(dbus.service.Object):
     def appearance(self, appearance):
         self.Set(constants.LE_ADVERTISEMENT_IFACE, 'Appearance', appearance)
 
+    @property
+    def min_interval(self):
+        """List of UUIDs that represent available services."""
+        return self.Get(constants.LE_ADVERTISEMENT_IFACE, 'MinInterval')
+
+    @min_interval.setter
+    def min_interval(self, value):
+        self.Set(constants.LE_ADVERTISEMENT_IFACE, 'MinInterval', value)
+
+    @property
+    def max_interval(self):
+        """List of UUIDs that represent available services."""
+        return self.Get(constants.LE_ADVERTISEMENT_IFACE, 'MaxInterval')
+
+    @max_interval.setter
+    def max_interval(self, value):
+        self.Set(constants.LE_ADVERTISEMENT_IFACE, 'MaxInterval', value)
+
     @dbus.service.method(constants.DBUS_PROP_IFACE,
                          in_signature='s',
                          out_signature='a{sv}')
@@ -223,6 +243,12 @@ class Advertisement(dbus.service.Object):
         if self.props[interface_name]['Appearance'] is not None:
             response['Appearance'] = dbus.UInt16(
                     self.props[interface_name]['Appearance'])
+        if self.props[interface_name]['MinInterval'] is not None:
+            response['MinInterval'] = dbus.UInt32(
+                    self.props[interface_name]['MinInterval'])
+        if self.props[interface_name]['MaxInterval'] is not None:
+            response['MaxInterval'] = dbus.UInt32(
+                    self.props[interface_name]['MaxInterval'])
         response['Includes'] = dbus.Array(
             self.props[interface_name]['Includes'], signature='s')
 

--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -24,9 +24,22 @@ class Peripheral:
         self.dongle = adapter.Adapter(adapter_address)
         self.local_name = local_name
         self.appearance = appearance
+        self.min_advertising_interval = None
+        self.max_advertising_interval = None
         self.advert = advertisement.Advertisement(1, 'peripheral')
         self.ad_manager = advertisement.AdvertisingManager(adapter_address)
         self.mainloop = async_tools.EventLoop()
+
+    def set_advertising_interval(self, min, max):
+        """
+        Set the advertising interval for the ble service in milliseconds (ms)
+        Need to set Experimental: True in /etc/bluetooth/main.conf
+
+        :param min: min interval of advertising
+        :param max: max interval of advertising
+        """
+        self.min_advertising_interval = min
+        self.max_advertising_interval = max
 
     def add_service(self, srv_id, uuid, primary):
         """
@@ -126,6 +139,10 @@ class Peripheral:
             self.advert.local_name = self.local_name
         if self.appearance:
             self.advert.appearance = self.appearance
+        if self.min_advertising_interval:
+            self.advert.min_interval = self.min_advertising_interval
+        if self.max_advertising_interval:
+            self.advert.max_interval = self.max_advertising_interval
 
     def publish(self):
         """Create advertisement and make peripheral visible"""


### PR DESCRIPTION
Adds the ability to set the advertising interval for a BLE server.
It has been tested with Bluez 5.72 with the experimental flag on.

Experimental flag can be put on by adding 

```
Experimental = true
```
to `/etc/bluetooth/main.conf` and restart.

I put the setting in a separate function to keep the main interface as clean as possible, as this feature is still experimental.