### PR TITLE
Give option to not advertise a primary service

### DIFF
--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -20,7 +20,7 @@ class Peripheral:
         self.services = []
         self.characteristics = []
         self.descriptors = []
-        self.primary_services = []
+        self.advertised_services = []
         self.dongle = adapter.Adapter(adapter_address)
         self.local_name = local_name
         self.appearance = appearance
@@ -28,18 +28,22 @@ class Peripheral:
         self.ad_manager = advertisement.AdvertisingManager(adapter_address)
         self.mainloop = async_tools.EventLoop()
 
-    def add_service(self, srv_id, uuid, primary):
+    def add_service(self, srv_id, uuid, primary, advertised=None):
         """
         Add the service information required
 
         :param srv_id: integer between 0 & 9999 as unique reference
         :param uuid: The Bluetooth uuid number for this service
-        :param primary: boolean for if this service should be advertised
+        :param primary: boolean for if this service is primary
+        :param advertised: boolean for if this service should be advertised, or None
 
         """
+        if advertised is None:
+            advertised = primary
+
         self.services.append(localGATT.Service(srv_id, uuid, primary))
-        if primary:
-            self.primary_services.append(uuid)
+        if advertised:
+            self.advertised_services.append(uuid)
 
     def add_characteristic(self, srv_id, chr_id, uuid, value,
                            notifying, flags,
@@ -121,7 +125,7 @@ class Peripheral:
         ))
 
     def _create_advertisement(self):
-        self.advert.service_UUIDs = self.primary_services
+        self.advert.service_UUIDs = self.advertised_services
         if self.local_name:
             self.advert.local_name = self.local_name
         if self.appearance:

--- a/bluezero/peripheral.py
+++ b/bluezero/peripheral.py
@@ -35,7 +35,8 @@ class Peripheral:
         :param srv_id: integer between 0 & 9999 as unique reference
         :param uuid: The Bluetooth uuid number for this service
         :param primary: boolean for if this service is primary
-        :param advertised: boolean for if this service should be advertised, or None
+        :param advertised: boolean for if this service should be advertised, 
+        or None
 
         """
         if advertised is None:


### PR DESCRIPTION
`add_service` has an additional argument `advertised` which is `None` by default. 
if `advertised is None`, then the behavior is unchanged compared to before.
if `advertised` is `True` or `False`, its value is used to determine whether the service should be advertised.

Since `advertised` has default value `None`, this pull request is backwards compatible with all existing bluezero code.
In addition, it gives developers the option to not advertise a primary service. This is useful because BLE has a maximum advertising size of [31 bytes](https://docs.silabs.com/bluetooth/6.2.0/bluetooth-fundamentals-advertising-scanning/advertising-data-basics), and a service UUID can use up to 16 bytes, which leaves little or no room for [other data](https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile).  